### PR TITLE
feat: gcode_shell_command: option to terminate or not subprocess

### DIFF
--- a/resources/gcode_shell_command.py
+++ b/resources/gcode_shell_command.py
@@ -18,6 +18,7 @@ class ShellCommand:
         self.command = shlex.split(cmd)
         self.timeout = config.getfloat('timeout', 2., above=0.)
         self.verbose = config.getboolean('verbose', True)
+        self.terminate = config.getboolean('terminate', True)
         self.proc_fd = None
         self.partial_output = ""
         self.gcode.register_mux_command(
@@ -68,7 +69,7 @@ class ShellCommand:
             if proc.poll() is not None:
                 complete = True
                 break
-        if not complete:
+        if not complete and self.terminate:
             proc.terminate()
         if self.verbose:
             if self.partial_output:


### PR DESCRIPTION
Hi @th33xitus,

I'm using `gcode_shell_command` to take a timelapse (with gphoto and an external camera plugged in usb). I set as many camera settings as possible in manual mode so the photography process is quite fast (less than 1s). But after that, I copy the image file to a network drive. This part takes up to 10 seconds.

I dont want to pause the print job for something that can be made in background. So I just added a config for the `gcode_shell_command` in order to let the subprocess continue if I want to.

I know that this is far from perfect (could may be add a second "safety" timeout to actually terminate the subprocess) but may be it could help other users.

Anyway, thank you for you work. Regards
