### PR TITLE
refactor: show full path of mcu

### DIFF
--- a/scripts/flash_klipper.sh
+++ b/scripts/flash_klipper.sh
@@ -112,7 +112,6 @@ function print_detected_mcu_to_screen() {
   fi
 
   for mcu in "${mcu_list[@]}"; do
-    mcu=$(echo "${mcu}" | rev | cut -d"/" -f1 | rev)
     echo -e " ● MCU #${i}: ${cyan}${mcu}${white}"
     i=$(( i + 1 ))
   done


### PR DESCRIPTION
In *4) [Advanced]* --> *5) [Get MCU ID]* display the full path for USB connected MCUs instead of only the serial file name