### PR TITLE
fix: fix typo in example.printer.cfg

### DIFF
--- a/resources/example.printer.cfg
+++ b/resources/example.printer.cfg
@@ -1,7 +1,7 @@
 [mcu]
 serial: /dev/serial/by-id/<your-mcu-id>
 
-[virtual_sd_card]
+[virtual_sdcard]
 path: %GCODES_DIR%
 on_error_gcode: CANCEL_PRINT
 


### PR DESCRIPTION
This PR rename virtual_sd_card to virtual_sdcard in example.printer.cfg