### PR TITLE
refactor(Klipper): trim klipper git clone to only latest history

### DIFF
--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -264,7 +264,7 @@ function clone_klipper() {
   status_msg "Cloning Klipper from ${repo} ..."
 
   cd "${HOME}" || exit 1
-  if git clone "${repo}" "${KLIPPER_DIR}"; then
+  if git clone "${repo}" "${KLIPPER_DIR}" --depth 1; then
     cd "${KLIPPER_DIR}" && git checkout "${branch}"
   else
     print_error "Cloning Klipper from\n ${repo}\n failed!"


### PR DESCRIPTION
I was receiving the following error on my Raspberry Pi Zero 2 W during the installation of Klipper, while running the 64-bit lite version of Raspberry Pi OS (bookworm).2

```
error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
```

I tracked this down to a likely low memory issue due to the size of the git repo. I was able to correct for this issue, by only downloading the tip of the history of the Klipper repo during install by setting `--depth 1` in the `git clone` command.  This resulted in a roughly 13x reduction in the size of the downloaded repo and allowed me to continue my install without issue using KIAUH.