### PR TITLE
feat: allow non-github klipper repositories, as well as ssh cloning

### DIFF
--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -253,8 +253,12 @@ function clone_klipper() {
   local repo=${1} branch=${2}
 
   [[ -z ${repo} ]] && repo="${KLIPPER_REPO}"
-  repo=$(echo "${repo}" | sed -r "s/^(http|https):\/\/github\.com\///i; s/\.git$//")
-  repo="https://github.com/${repo}"
+  if [[ "${repo}" =~ ^(http|https):\/\/github.com || ! "$repo" =~ ^(http|https):\/\/ && ! "$repo" =~ ^git@ ]]; then
+    repo=$(echo "${repo}" | sed -r "s/^(http|https):\/\/github\.com\///i; s/\.git$//")
+    repo="https://github.com/${repo}"
+  else
+    repo=${repo}
+  fi
 
   [[ -z ${branch} ]] && branch="master"
 


### PR DESCRIPTION
This change allows users to use Klipper repositories other than github.com, including gitlab.com.

This addresses #398 as well as including the functionality from the open PR #323 regarding ssh cloning (since, they both touch the same line of code, in effectively the same way)
