### PR TITLE
Add Klipper-Backup to KIAUH

### DIFF
--- a/kiauh/extensions/klipper_backup/__init__.py
+++ b/kiauh/extensions/klipper_backup/__init__.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 EXT_MODULE_NAME = "klipper_backup_extension.py"
 MODULE_PATH = Path(__file__).resolve().parent
+MOONRAKER_CONF = Path.home().joinpath("printer_data", "config", "moonraker.conf")
 KLIPPERBACKUP_DIR = Path.home().joinpath("klipper-backup")
 KLIPPERBACKUP_CONFIG_DIR = Path.home().joinpath("config_backup")
 KLIPPERBACKUP_REPO_URL = "https://github.com/staubgeborener/klipper-backup"

--- a/kiauh/extensions/klipper_backup/__init__.py
+++ b/kiauh/extensions/klipper_backup/__init__.py
@@ -1,5 +1,5 @@
 # ======================================================================= #
-#  Copyright (C) 2023 - 2024 Staubgeborener                               #
+#  Copyright (C) 2023 - 2024 Staubgeborener and Tylerjet                  #
 #  https://github.com/Staubgeborener/klipper-backup                       #
 #                                                                         #
 #  This file is part of KIAUH - Klipper Installation And Update Helper    #

--- a/kiauh/extensions/klipper_backup/__init__.py
+++ b/kiauh/extensions/klipper_backup/__init__.py
@@ -1,0 +1,23 @@
+# ======================================================================= #
+#  Copyright (C) 2023 - 2024 Staubgeborener                               #
+#  https://github.com/Staubgeborener/klipper-backup                       #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+
+from pathlib import Path
+
+EXT_MODULE_NAME = "klipper_backup_extension.py"
+MODULE_PATH = Path(__file__).resolve().parent
+MODULE_ASSETS = MODULE_PATH.joinpath("assets")
+KLIPPER_DIR = Path.home().joinpath("klipper-backup")
+KLIPPERBACKUP_DIR = Path.home().joinpath("klipper-backup")
+KLIPPERBACKUP_CONFIG_DIR = Path.home().joinpath("config_backup")
+DEFAULT_KLIPPERBACKUP_REPO_URL = "https://github.com/staubgeborener/klipper-backup"
+KLIPPER_EXTRAS = KLIPPER_DIR.joinpath("klippy/extras")
+EXTENSION_SRC = MODULE_ASSETS.joinpath(EXT_MODULE_NAME)
+EXTENSION_TARGET_PATH = KLIPPERBACKUP_DIR
+EXAMPLE_CFG_SRC = MODULE_ASSETS.joinpath("shell_command.cfg")

--- a/kiauh/extensions/klipper_backup/__init__.py
+++ b/kiauh/extensions/klipper_backup/__init__.py
@@ -14,6 +14,4 @@ EXT_MODULE_NAME = "klipper_backup_extension.py"
 MODULE_PATH = Path(__file__).resolve().parent
 KLIPPERBACKUP_DIR = Path.home().joinpath("klipper-backup")
 KLIPPERBACKUP_CONFIG_DIR = Path.home().joinpath("config_backup")
-DEFAULT_KLIPPERBACKUP_REPO_URL = "https://github.com/staubgeborener/klipper-backup"
-EXTENSION_SRC = MODULE_ASSETS.joinpath(EXT_MODULE_NAME)
-EXTENSION_TARGET_PATH = KLIPPERBACKUP_DIR
+KLIPPERBACKUP_REPO_URL = "https://github.com/staubgeborener/klipper-backup"

--- a/kiauh/extensions/klipper_backup/__init__.py
+++ b/kiauh/extensions/klipper_backup/__init__.py
@@ -12,12 +12,8 @@ from pathlib import Path
 
 EXT_MODULE_NAME = "klipper_backup_extension.py"
 MODULE_PATH = Path(__file__).resolve().parent
-MODULE_ASSETS = MODULE_PATH.joinpath("assets")
-KLIPPER_DIR = Path.home().joinpath("klipper-backup")
 KLIPPERBACKUP_DIR = Path.home().joinpath("klipper-backup")
 KLIPPERBACKUP_CONFIG_DIR = Path.home().joinpath("config_backup")
 DEFAULT_KLIPPERBACKUP_REPO_URL = "https://github.com/staubgeborener/klipper-backup"
-KLIPPER_EXTRAS = KLIPPER_DIR.joinpath("klippy/extras")
 EXTENSION_SRC = MODULE_ASSETS.joinpath(EXT_MODULE_NAME)
 EXTENSION_TARGET_PATH = KLIPPERBACKUP_DIR
-EXAMPLE_CFG_SRC = MODULE_ASSETS.joinpath("shell_command.cfg")

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -18,6 +18,7 @@ from extensions.klipper_backup import (
     KLIPPERBACKUP_REPO_URL,
     KLIPPERBACKUP_DIR,
     KLIPPERBACKUP_CONFIG_DIR,
+    MOONRAKER_CONF,
 )
 
 from utils.filesystem_utils import check_file_exist
@@ -79,7 +80,7 @@ class KlipperbackupExtension(BaseExtension):
             return
 
         def remove_moonraker_entry():
-            original_file_path = os.path.join(str(MOONRAKER_DIR), 'printer_data', 'config', 'moonraker.conf')
+            original_file_path = MOONRAKER_CONF
             comparison_file_path = os.path.join(str(KLIPPERBACKUP_DIR), 'install-files', 'moonraker.conf')
             if not os.path.exists(original_file_path) or not os.path.exists(comparison_file_path):
                 return False
@@ -87,7 +88,8 @@ class KlipperbackupExtension(BaseExtension):
                 original_content = original_file.read()
                 comparison_content = comparison_file.read().strip()
             if comparison_content in original_content:
-                modified_content = original_content.replace(comparison_content, '')
+                modified_content = original_content.replace(comparison_content, '').strip()
+                modified_content = "\n".join(line for line in modified_content.split("\n") if line.strip())
                 with open(original_file_path, 'w') as original_file:
                     original_file.write(modified_content)
                     return True

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -13,7 +13,6 @@ import subprocess
 
 from extensions.base_extension import BaseExtension
 from extensions.klipper_backup import (
-    EXTENSION_TARGET_PATH,
     DEFAULT_KLIPPERBACKUP_REPO_URL,
     KLIPPERBACKUP_DIR,
     KLIPPERBACKUP_CONFIG_DIR,
@@ -33,7 +32,7 @@ class KlipperbackupExtension(BaseExtension):
         subprocess.run([str(KLIPPERBACKUP_DIR / "install.sh"), "kiauh", "install_repo"])
 
     def update_extension(self, **kwargs) -> None:
-        extension_installed = check_file_exist(EXTENSION_TARGET_PATH)
+        extension_installed = check_file_exist(KLIPPERBACKUP_DIR)
         if not extension_installed:
             Logger.print_info("Extension does not seem to be installed! Skipping ...")
             return
@@ -41,7 +40,7 @@ class KlipperbackupExtension(BaseExtension):
             subprocess.run([str(KLIPPERBACKUP_DIR / "install.sh"), "kiauh", "check_updates"])
 
     def remove_extension(self, **kwargs) -> None:
-        extension_installed = check_file_exist(EXTENSION_TARGET_PATH)
+        extension_installed = check_file_exist(KLIPPERBACKUP_DIR)
         if not extension_installed:
             Logger.print_info("Extension does not seem to be installed! Skipping ...")
             return
@@ -49,8 +48,8 @@ class KlipperbackupExtension(BaseExtension):
         question = "Do you really want to remove the extension?"
         if get_confirm(question, True, False):
             try:
-                Logger.print_status(f"Removing '{EXTENSION_TARGET_PATH}' ...")
-                shutil.rmtree(EXTENSION_TARGET_PATH)
+                Logger.print_status(f"Removing '{KLIPPERBACKUP_DIR}' ...")
+                shutil.rmtree(KLIPPERBACKUP_DIR)
                 config_backup_exists = check_file_exist(KLIPPERBACKUP_CONFIG_DIR)
                 if config_backup_exists:
                     shutil.rmtree(KLIPPERBACKUP_CONFIG_DIR)

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -30,7 +30,7 @@ class KlipperbackupExtension(BaseExtension):
     def install_extension(self, **kwargs) -> None:
         if not KLIPPERBACKUP_DIR.exists():
             subprocess.run(["git", "clone", str(KLIPPERBACKUP_REPO_URL), str(KLIPPERBACKUP_DIR)])
-            subprocess.run(["git", "-C", str(KLIPPERBACKUP_DIR), "checkout", "installer-dev"])
+            #subprocess.run(["git", "-C", str(KLIPPERBACKUP_DIR), "checkout", "installer-dev"]) # Only for testing
             subprocess.run(["chmod", "+x", str(KLIPPERBACKUP_DIR / "install.sh")])
         subprocess.run([str(KLIPPERBACKUP_DIR / "install.sh")])
 

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -1,5 +1,6 @@
 # ======================================================================= #
-#  Copyright (C) 2020 - 2024 Dominik Willner <th33xitus@gmail.com>        #
+#  Copyright (C) 2023 - 2024 Staubgeborener                               #
+#  https://github.com/Staubgeborener/klipper-backup                       #
 #                                                                         #
 #  This file is part of KIAUH - Klipper Installation And Update Helper    #
 #  https://github.com/dw-0/kiauh                                          #
@@ -7,25 +8,15 @@
 #  This file may be distributed under the terms of the GNU GPLv3 license  #
 # ======================================================================= #
 
-import os
 import shutil
 import subprocess
-from typing import List
 
-from components.klipper.klipper import Klipper
-from core.backup_manager.backup_manager import BackupManager
 from extensions.base_extension import BaseExtension
-from core.config_manager.config_manager import ConfigManager
-from core.instance_manager.instance_manager import InstanceManager
 from extensions.klipper_backup import (
     EXTENSION_TARGET_PATH,
-    EXTENSION_SRC,
-    KLIPPER_DIR,
     DEFAULT_KLIPPERBACKUP_REPO_URL,
     KLIPPERBACKUP_DIR,
     KLIPPERBACKUP_CONFIG_DIR,
-    EXAMPLE_CFG_SRC,
-    KLIPPER_EXTRAS,
 )
 from utils.filesystem_utils import check_file_exist
 from utils.input_utils import get_confirm

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -1,5 +1,5 @@
 # ======================================================================= #
-#  Copyright (C) 2023 - 2024 Staubgeborener                               #
+#  Copyright (C) 2023 - 2024 Staubgeborener and Tylerjet                  #
 #  https://github.com/Staubgeborener/klipper-backup                       #
 #                                                                         #
 #  This file is part of KIAUH - Klipper Installation And Update Helper    #

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -1,0 +1,68 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2024 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+
+import os
+import shutil
+import subprocess
+from typing import List
+
+from components.klipper.klipper import Klipper
+from core.backup_manager.backup_manager import BackupManager
+from extensions.base_extension import BaseExtension
+from core.config_manager.config_manager import ConfigManager
+from core.instance_manager.instance_manager import InstanceManager
+from extensions.klipper_backup import (
+    EXTENSION_TARGET_PATH,
+    EXTENSION_SRC,
+    KLIPPER_DIR,
+    DEFAULT_KLIPPERBACKUP_REPO_URL,
+    KLIPPERBACKUP_DIR,
+    KLIPPERBACKUP_CONFIG_DIR,
+    EXAMPLE_CFG_SRC,
+    KLIPPER_EXTRAS,
+)
+from utils.filesystem_utils import check_file_exist
+from utils.input_utils import get_confirm
+from utils.logger import Logger
+
+
+# noinspection PyMethodMayBeStatic
+class KlipperbackupExtension(BaseExtension):
+    def install_extension(self, **kwargs) -> None:
+        if not KLIPPERBACKUP_DIR.exists():
+            subprocess.run(["git", "clone", str(DEFAULT_KLIPPERBACKUP_REPO_URL), str(KLIPPERBACKUP_DIR)])
+            subprocess.run(["git", "-C", str(KLIPPERBACKUP_DIR), "checkout", "installer-dev"])
+            subprocess.run(["chmod", "+x", str(KLIPPERBACKUP_DIR / "install.sh")])
+        subprocess.run([str(KLIPPERBACKUP_DIR / "install.sh"), "kiauh", "install_repo"])
+
+    def update_extension(self, **kwargs) -> None:
+        extension_installed = check_file_exist(EXTENSION_TARGET_PATH)
+        if not extension_installed:
+            Logger.print_info("Extension does not seem to be installed! Skipping ...")
+            return
+        else:
+            subprocess.run([str(KLIPPERBACKUP_DIR / "install.sh"), "kiauh", "check_updates"])
+
+    def remove_extension(self, **kwargs) -> None:
+        extension_installed = check_file_exist(EXTENSION_TARGET_PATH)
+        if not extension_installed:
+            Logger.print_info("Extension does not seem to be installed! Skipping ...")
+            return
+
+        question = "Do you really want to remove the extension?"
+        if get_confirm(question, True, False):
+            try:
+                Logger.print_status(f"Removing '{EXTENSION_TARGET_PATH}' ...")
+                shutil.rmtree(EXTENSION_TARGET_PATH)
+                config_backup_exists = check_file_exist(KLIPPERBACKUP_CONFIG_DIR)
+                if config_backup_exists:
+                    shutil.rmtree(KLIPPERBACKUP_CONFIG_DIR)
+                Logger.print_ok("Extension successfully removed!")
+            except OSError as e:
+                Logger.print_error(f"Unable to remove extension: {e}")

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -44,17 +44,14 @@ class KlipperbackupExtension(BaseExtension):
 
         def is_service_installed(service_name):
             try:
-                # Führe den Befehl aus und leite stdout und stderr in den Null-Geräte
                 with open(os.devnull, 'w') as devnull:
                     subprocess.run(["systemctl", "status", service_name], stdout=devnull, stderr=devnull, check=True)
                 return True
             except subprocess.CalledProcessError:
-                # Wenn ein Fehler auftritt, bedeutet das, dass der Dienst nicht installiert ist
                 return False
 
         def uninstall_service(service_name):
            try:
-                # Deinstalliere den Dienst, indem du den Befehl "systemctl disable" und "systemctl stop" ausführst
                 subprocess.run(["sudo", "systemctl", "disable", service_name], check=True)
                 subprocess.run(["sudo", "systemctl", "stop", service_name], check=True)
                 Logger.print_ok(f"The service {service_name} has been successfully uninstalled.")

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -13,7 +13,7 @@ import subprocess
 
 from extensions.base_extension import BaseExtension
 from extensions.klipper_backup import (
-    DEFAULT_KLIPPERBACKUP_REPO_URL,
+    KLIPPERBACKUP_REPO_URL,
     KLIPPERBACKUP_DIR,
     KLIPPERBACKUP_CONFIG_DIR,
 )
@@ -26,7 +26,7 @@ from utils.logger import Logger
 class KlipperbackupExtension(BaseExtension):
     def install_extension(self, **kwargs) -> None:
         if not KLIPPERBACKUP_DIR.exists():
-            subprocess.run(["git", "clone", str(DEFAULT_KLIPPERBACKUP_REPO_URL), str(KLIPPERBACKUP_DIR)])
+            subprocess.run(["git", "clone", str(KLIPPERBACKUP_REPO_URL), str(KLIPPERBACKUP_DIR)])
             subprocess.run(["git", "-C", str(KLIPPERBACKUP_DIR), "checkout", "installer-dev"])
             subprocess.run(["chmod", "+x", str(KLIPPERBACKUP_DIR / "install.sh")])
         subprocess.run([str(KLIPPERBACKUP_DIR / "install.sh"), "kiauh", "install_repo"])

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -12,7 +12,6 @@ import os
 import shutil
 import subprocess
 
-from components.moonraker import MOONRAKER_DIR
 from extensions.base_extension import BaseExtension
 from extensions.klipper_backup import (
     KLIPPERBACKUP_REPO_URL,

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -85,7 +85,7 @@ class KlipperbackupExtension(BaseExtension):
                 return False
             with open(original_file_path, 'r') as original_file, open(comparison_file_path, 'r') as comparison_file:
                 original_content = original_file.read()
-                comparison_content = comparison_file.read().strip()
+                comparison_content = comparison_file.read()
             if comparison_content in original_content:
                 modified_content = original_content.replace(comparison_content, '').strip()
                 modified_content = "\n".join(line for line in modified_content.split("\n") if line.strip())

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -46,6 +46,7 @@ class KlipperbackupExtension(BaseExtension):
         def is_service_installed(service_name):
             command = ["systemctl", "status", service_name]
             result = subprocess.run(command, capture_output=True, text=True)
+            # Doesn't matter whether the service is active or not, what matters is whether it is installed. So let's search for "Loaded:" in stdout
             if "Loaded:" in result.stdout:
                 return True
             else:
@@ -58,9 +59,9 @@ class KlipperbackupExtension(BaseExtension):
                 subprocess.run(["sudo", "systemctl", "daemon-reload"], check=True)
                 service_path = f'/etc/systemd/system/{service_name}'
                 os.system(f'sudo rm {service_path}')
-                Logger.print_ok(f"The service {service_name} has been successfully uninstalled.")
+                return True
             except subprocess.CalledProcessError:
-                Logger.print_error(f"Error uninstalling the service {service_name}.")
+                return False
 
         def check_crontab_entry(entry):
             try:
@@ -103,7 +104,10 @@ class KlipperbackupExtension(BaseExtension):
                     Logger.print_status(f"Check whether the service {service_name} is installed ...")
                     if is_service_installed(service_name):
                         Logger.print_info(f"Service {service_name} detected.")
-                        uninstall_service(service_name)
+                        if uninstall_service(service_name):
+                            Logger.print_ok(f"The service {service_name} has been successfully uninstalled.")
+                        else:
+                            Logger.print_error(f"Error uninstalling the service {service_name}.")
                     else:
                         Logger.print_info(f"The service {service_name} is not installed. Skipping ...")
                 except:

--- a/kiauh/extensions/klipper_backup/klipper_backup_extension.py
+++ b/kiauh/extensions/klipper_backup/klipper_backup_extension.py
@@ -67,7 +67,6 @@ class KlipperbackupExtension(BaseExtension):
                 crontab_content = subprocess.check_output(["crontab", "-l"], stderr=subprocess.DEVNULL, text=True)
             except subprocess.CalledProcessError:
                 return False
-
             for line in crontab_content.splitlines():
                 if entry in line:
                     return True
@@ -81,14 +80,11 @@ class KlipperbackupExtension(BaseExtension):
         def remove_moonraker_entry():
             original_file_path = os.path.join(str(MOONRAKER_DIR), 'printer_data', 'config', 'moonraker.conf')
             comparison_file_path = os.path.join(str(KLIPPERBACKUP_DIR), 'install-files', 'moonraker.conf')
-
             if not os.path.exists(original_file_path) or not os.path.exists(comparison_file_path):
                 return False
-
             with open(original_file_path, 'r') as original_file, open(comparison_file_path, 'r') as comparison_file:
                 original_content = original_file.read()
                 comparison_content = comparison_file.read().strip()
-
             if comparison_content in original_content:
                 modified_content = original_content.replace(comparison_content, '')
                 with open(original_file_path, 'w') as original_file:

--- a/kiauh/extensions/klipper_backup/metadata.json
+++ b/kiauh/extensions/klipper_backup/metadata.json
@@ -1,0 +1,10 @@
+{
+  "metadata": {
+    "index": 3,
+    "module": "klipper_backup_extension",
+    "maintained_by": "Staubgeborener",
+    "display_name": "Klipper-Backup",
+    "description": "Backup all your klipper files in GitHub",
+    "updates": true
+  }
+}


### PR DESCRIPTION
As [previously](https://github.com/dw-0/kiauh/issues/435) discussed, here is the PR for an integration of [Klipper-Backup](https://github.com/Staubgeborener/klipper-backup) (installation / update / remove). It is written in python so that it can be released directly together with KIAUH v6.

For test purposes, the comment in [line 33](https://github.com/Staubgeborener/kiauh/blob/kiauh-v6-dev/kiauh/extensions/klipper_backup/klipper_backup_extension.py#L33C1-L33C32) must be removed, so that we switch to the (currently!) valid branch. This will be merged into the main branch in the coming weeks (i think sometime in may), so that it can remain commented at this point.