### PR TITLE
do not mess with klipper url, allow access via ssh or sites like gitlab, alternate to #452

### DIFF
--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -253,8 +253,9 @@ function clone_klipper() {
   local repo=${1} branch=${2}
 
   [[ -z ${repo} ]] && repo="${KLIPPER_REPO}"
-  repo=$(echo "${repo}" | sed -r "s/^(http|https):\/\/github\.com\///i; s/\.git$//")
-  repo="https://github.com/${repo}"
+  if [[ $repo != *://* ]]; then
+    repo="https://github.com/${repo}"
+  fi
 
   [[ -z ${branch} ]] && branch="master"
 

--- a/scripts/switch_klipper_repo.sh
+++ b/scripts/switch_klipper_repo.sh
@@ -22,7 +22,9 @@ function change_klipper_repo_menu() {
 
   ### generate the repolist from the klipper_repos.txt textfile
   while IFS="," read -r repo branch; do
-    repo=$(echo "${repo}" | sed -r "s/^http(s)?:\/\/github.com\///" | sed "s/\.git$//" )
+    if [[ $repo != *://* ]]; then
+      repo="https://github.com/${repo}"
+    fi
     repos+=("${repo}")
     ### if branch is not given, default to 'master'
     [[ -z ${branch} ]] && branch="master"


### PR DESCRIPTION
like #452, which says
"This addresses #398 as well as including the functionality from the open PR #323 regarding ssh cloning (since, they both touch the same line of code, in effectively the same way)"

the git url for klipper can be on other schemes like `ssh://` or `https://gitlab`.

Additionally, if there is a need to use `http://` e.g. because of firewall rules etc. then the current code would not allow this, because it removes the `http://github.com/` and adds `https://github.com/`.

Actually, I would just remove the code that messes with the url.

I only inserted the addition of `https://github.com/` for compatibility in case the configuration does not contain a full url.

Not sure why the `.git` was removed but not added afterwards. The official github clone url would have a `.git` at the end.
Also,  in clone_klipper the sed command uses the `i`-flag, but not in `switch_clipper_repo_menu`.

Not messing with the url would remove the duplicate code of the same thing.
Alternatively, the url could be normalized in a central function, e.g. `normalize_git_url`.