### PR TITLE
feat: add Spoolman support

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -45,13 +45,13 @@ function backup_config_dir() {
     for folder in ${config_pathes}; do
       if [[ -d ${folder} ]]; then
         status_msg "Create backup of ${folder} ..."
-  
+
         folder_name=$(echo "${folder}" | rev | cut -d"/" -f2 | rev)
         target_dir="${BACKUP_DIR}/configs/${current_date}/${folder_name}"
         mkdir -p "${target_dir}"
         cp -r "${folder}" "${target_dir}"
         i=$(( i + 1 ))
-  
+
         ok_msg "Backup created in:\n${target_dir}"
       fi
     done
@@ -211,5 +211,21 @@ function backup_octoeverywhere() {
     print_confirm "OctoEverywhere backup complete!"
   else
     print_error "Can't back up OctoEverywhere directory!\n Not found!"
+  fi
+}
+
+function backup_spoolman() {
+  local current_date
+
+  if [[ -d ${SPOOLMAN_DIR} ]] ; then
+    status_msg "Creating Spoolman backup ..."
+    check_for_backup_dir
+    current_date=$(get_date)
+    status_msg "Timestamp: ${current_date}"
+    mkdir -p "${BACKUP_DIR}/Spoolman-backups/${current_date}"
+    cp -r "${SPOOLMAN_DIR}" "${_}" && cp -r "${SPOOLMAN_DB_DIR}/spoolman.db" "${_}"
+    print_confirm "Spoolman backup complete!"
+  else
+    print_error "Can't back up Spoolman directory!\n Not found!"
   fi
 }

--- a/scripts/globals.sh
+++ b/scripts/globals.sh
@@ -87,4 +87,8 @@ function set_globals() {
   OCTOAPP_ENV="${HOME}/octoapp-env"
   OCTOAPP_DIR="${HOME}/octoapp"
   OCTOAPP_REPO="https://github.com/crysxd/OctoApp-Plugin.git"
+
+  #=============== Spoolman ================#
+  SPOOLMAN_DIR="${HOME}/spoolman"
+  SPOOLMAN_REPO="https://api.github.com/repos/Donkie/Spoolman/releases/latest"
 }

--- a/scripts/globals.sh
+++ b/scripts/globals.sh
@@ -90,5 +90,6 @@ function set_globals() {
 
   #=============== Spoolman ================#
   SPOOLMAN_DIR="${HOME}/spoolman"
+  SPOOLMAN_DB_DIR="${HOME}/.local/share/spoolman"
   SPOOLMAN_REPO="https://api.github.com/repos/Donkie/Spoolman/releases/latest"
 }

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -62,6 +62,8 @@ function remove_spoolman(){
     do_action_service "stop" "Spoolman"
     do_action_service "disable" "Spoolman"
     sudo rm -f "${SYSTEMD}/Spoolman.service"
+    sudo systemctl daemon-reload
+    sudo systemctl reset-failed
     ok_msg "Spoolman service removed!"
 
     status_msg "Removing spoolman directory..."

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+#=======================================================================#
+# Copyright (C) 2020 - 2024 Dominik Willner <th33xitus@gmail.com>       #
+#                                                                       #
+# This file is part of KIAUH - Klipper Installation And Update Helper   #
+# https://github.com/dw-0/kiauh                                         #
+#                                                                       #
+# This file may be distributed under the terms of the GNU GPLv3 license #
+#=======================================================================#
+
+# Error Handling
+set -e
+
+function install_spoolman() {
+
+  pushd "${HOME}" &> /dev/null || exit 1
+
+  dependency_check curl jq
+
+  if [[ ! -d "${SPOOLMAN_DIR}" && -z "$(ls -A "${SPOOLMAN_DIR}" 2> /dev/null)" ]]; then
+    status_msg "Downloading spoolman..."
+    setup_spoolman_folder
+    status_msg "Downloading complete"
+    start_install_script
+    advanced_config_prompt
+  else
+    ### In case spoolman is "incomplete" rerun install script
+    if get_spoolman_status | grep -q "Incomplete!"; then
+      start_install_script
+      exit 1
+    fi
+
+    ok_msg "Spoolman already installed"
+    exit 1
+  fi
+
+  enable_moonraker_integration_prompt
+  patch_spoolman_update_manager
+}
+function update_moonraker_configs() {
+  local patched moonraker_configs regex env_port
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
+  moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
+
+  patched="false"
+  for conf in ${moonraker_configs}; do
+    if ! grep -Eq "^\[update_manager KlipperScreen\]\s*$" "${conf}"; then
+      ### add new line to conf if it doesn't end with one
+      [[ $(tail -c1 "${conf}" | wc -l) -eq 0 ]] && echo "" >> "${conf}"
+      /bin/sh -c "cat >> ${conf}" << MOONRAKER_CONF
+${1}
+MOONRAKER_CONF
+    fi
+
+    patched="true"
+  done
+
+  if [[ ${patched} == "true" ]]; then
+    do_action_service "restart" "moonraker"
+  fi
+}
+
+function enable_moonraker_integration() {
+  local integration_str env_port
+  # get spoolman port from .env
+  env_port=$(grep "^SPOOLMAN_PORT=" "${SPOOLMAN_DIR}/.env" | cut -d"=" -f2)
+
+  integration_str="
+[spoolman]
+server: http://$(hostname -I | cut -d" " -f1):${env_port}
+"
+
+  status_msg "Adding Spoolman integration..."
+  update_moonraker_configs "${integration_str}"
+}
+
+function patch_spoolman_update_manager() {
+  local updater_str
+  updater_str="
+[update_manager Spoolman]
+type: zip
+channel: stable
+repo: Donkie/Spoolman
+path: ${SPOOLMAN_DIR}
+virtualenv: .venv
+requirements: requirements.txt
+persistent_files:
+  .venv
+  .env
+managed_services: Spoolman
+"
+
+  update_moonraker_configs "${updater_str}"
+}
+
+function advanced_config_prompt() {
+  local reply
+  while true; do
+    read -erp "${cyan}###### Continue with default configuration? (Y/n):${white} " reply
+    case "${reply}" in
+      Y|y|Yes|yes|"")
+        select_msg "Yes"
+        break;;
+      N|n|No|no)
+        select_msg "No"
+        advanced_config
+        break;;
+      *)
+        error_msg "Invalid Input!\n";;
+    esac
+  done
+  return 0
+}
+
+function enable_moonraker_integration_prompt() {
+  local reply
+  while true; do
+    read -erp "${cyan}###### Enable Moonraker integration? (Y/n):${white} " reply
+    case "${reply}" in
+      Y|y|Yes|yes|"")
+        select_msg "Yes"
+        enable_moonraker_integration
+        break;;
+      N|n|No|no)
+        select_msg "No"
+        break;;
+      *)
+        error_msg "Invalid Input!\n";;
+    esac
+  done
+  return 0
+}
+
+function advanced_config() {
+  status_msg "###### Advanced configuration"
+
+  local reply
+  while true; do
+    read -erp "${cyan}###### Select spoolman port (7912):${white} " reply
+    ### set default
+    if [[ -z "${reply}" ]]; then
+      reply="7912"
+    fi
+
+    select_msg "${reply}"
+    ### check if port is valid
+    if ! [[ "${reply}" =~ ^[0-9]+$ && "${reply}" -ge 1024 && "${reply}" -le 65535 ]]; then
+      error_msg "Invalid port number!\n"
+      continue
+    fi
+
+    ### update .env
+    sed -i "s/^SPOOLMAN_PORT=.*$/SPOOLMAN_PORT=${reply}/" "${SPOOLMAN_DIR}/.env"
+    do_action_service "restart" "Spoolman"
+    break
+  done
+  return 0
+}
+
+function setup_spoolman_folder() {
+  local source_url
+  ### get latest spoolman release url
+  source_url="$(curl -s "${SPOOLMAN_REPO}" | jq -r '.assets[] | select(.name == "spoolman.zip").browser_download_url')"
+
+  mkdir -p "${SPOOLMAN_DIR}"
+  curl -sSL "${source_url}" -o /tmp/temp.zip
+  unzip /tmp/temp.zip -d "${SPOOLMAN_DIR}" &> /dev/null
+  rm /tmp/temp.zip
+
+  chmod +x "${SPOOLMAN_DIR}"/scripts/install.sh
+}
+
+function start_install_script() {
+
+  pushd "${SPOOLMAN_DIR}" &> /dev/null || exit 1
+
+  if bash ./scripts/install.sh; then
+    ok_msg "Spoolman successfully installed!"
+  else
+    print_error "Spoolman installation failed!"
+    exit 1
+  fi
+}
+

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -54,6 +54,22 @@ function update_spoolman() {
   rm -rf "${SPOOLMAN_DIR}_old"
 }
 
+function remove_spoolman(){
+  if [[ -d "${SPOOLMAN_DIR}" ]]; then
+    status_msg "Removing spoolman service..."
+    do_action_service "stop" "Spoolman"
+    do_action_service "disable" "Spoolman"
+    sudo rm -f "${SYSTEMD}/Spoolman.service"
+    ok_msg "Spoolman service removed!"
+
+    status_msg "Removing spoolman directory..."
+    rm -rf "${SPOOLMAN_DIR}"
+    ok_msg "Spoolman directory removed!"
+  fi
+
+  print_confirm "Spoolman successfully removed!"
+}
+
 function update_moonraker_configs() {
   local patched moonraker_configs regex env_port
   regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -221,6 +221,7 @@ function get_spoolman_status() {
   files=(
       "${SPOOLMAN_DIR}"
       "${SYSTEMD}/Spoolman.service"
+      "${HOME}/.local/share/spoolman"
     )
 
   local count

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -183,3 +183,25 @@ function start_install_script() {
   fi
 }
 
+function get_spoolman_status() {
+  local -a files
+  files=(
+      "${SPOOLMAN_DIR}"
+      "${SYSTEMD}/Spoolman.service"
+    )
+
+  local count
+  count=0
+
+  for file in "${files[@]}"; do
+    [[ -e "${file}" ]] && count=$(( count +1 ))
+  done
+
+  if [[ "${count}" -eq "${#files[*]}" ]]; then
+    echo "Installed"
+  elif [[ "${count}" -gt 0 ]]; then
+    echo "Incomplete!"
+  else
+    echo "Not installed!"
+  fi
+}

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -69,6 +69,12 @@ function remove_spoolman(){
     ok_msg "Spoolman directory removed!"
   fi
 
+  if [[ -d "${HOME}/.local/share/spoolman" ]]; then
+    status_msg "Removing spoolman db..."
+    rm -rf "${HOME}/.local/share/spoolman"
+    ok_msg "Spoolman db removed!"
+  fi
+
   print_confirm "Spoolman successfully removed!"
 }
 

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -71,7 +71,7 @@ function remove_spoolman(){
 }
 
 function update_moonraker_configs() {
-  local patched moonraker_configs regex env_port
+  local moonraker_configs regex
   regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -84,7 +84,7 @@ function update_moonraker_configs() {
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 
   for conf in ${moonraker_configs}; do
-    if ! grep -Eq "^\[update_manager KlipperScreen\]\s*$" "${conf}"; then
+    if ! grep -Eq "^\[update_manager Spoolman\]\s*$" "${conf}"; then
       ### add new line to conf if it doesn't end with one
       [[ $(tail -c1 "${conf}" | wc -l) -eq 0 ]] && echo "" >> "${conf}"
       /bin/sh -c "cat >> ${conf}" << MOONRAKER_CONF

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -37,6 +37,8 @@ function install_spoolman() {
 
   enable_moonraker_integration_prompt
   patch_spoolman_update_manager
+
+  do_action_service "restart" "moonraker"
 }
 
 function update_spoolman() {
@@ -75,7 +77,6 @@ function update_moonraker_configs() {
   regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 
-  patched="false"
   for conf in ${moonraker_configs}; do
     if ! grep -Eq "^\[update_manager KlipperScreen\]\s*$" "${conf}"; then
       ### add new line to conf if it doesn't end with one
@@ -84,13 +85,7 @@ function update_moonraker_configs() {
 ${1}
 MOONRAKER_CONF
     fi
-
-    patched="true"
   done
-
-  if [[ ${patched} == "true" ]]; then
-    do_action_service "restart" "moonraker"
-  fi
 }
 
 function enable_moonraker_integration() {

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -69,9 +69,9 @@ function remove_spoolman(){
     ok_msg "Spoolman directory removed!"
   fi
 
-  if [[ -d "${HOME}/.local/share/spoolman" ]]; then
+  if [[ -d "${SPOOLMAN_DB_DIR}" ]]; then
     status_msg "Removing spoolman db..."
-    rm -rf "${HOME}/.local/share/spoolman"
+    rm -rf "${SPOOLMAN_DB_DIR}"
     ok_msg "Spoolman db removed!"
   fi
 
@@ -231,7 +231,7 @@ function get_spoolman_status() {
   files=(
       "${SPOOLMAN_DIR}"
       "${SYSTEMD}/Spoolman.service"
-      "${HOME}/.local/share/spoolman"
+      "${SPOOLMAN_DB_DIR}"
     )
 
   local count

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -125,6 +125,16 @@ managed_services: Spoolman
 "
 
   update_moonraker_configs "${updater_str}"
+
+  # add spoolman service to moonraker.asvc
+  local moonraker_asvc regex
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/moonraker\.asvc"
+  moonraker_asvc=$(find "${HOME}" -maxdepth 2 -type f -regextype posix-extended -regex "${regex}" | sort)
+
+  if [[ -n ${moonraker_asvc} ]]; then
+    status_msg "Adding Spoolman service to moonraker.asvc..."
+    /bin/sh -c "echo 'Spoolman' >> ${moonraker_asvc}"
+  fi
 }
 
 function advanced_config_prompt() {

--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -69,12 +69,6 @@ function remove_spoolman(){
     ok_msg "Spoolman directory removed!"
   fi
 
-  if [[ -d "${SPOOLMAN_DB_DIR}" ]]; then
-    status_msg "Removing spoolman db..."
-    rm -rf "${SPOOLMAN_DB_DIR}"
-    ok_msg "Spoolman db removed!"
-  fi
-
   print_confirm "Spoolman successfully removed!"
 }
 

--- a/scripts/ui/backup_menu.sh
+++ b/scripts/ui/backup_menu.sh
@@ -17,15 +17,18 @@ function backup_ui() {
   hr
   echo -e "| ${yellow}INFO: Backups are located in '~/kiauh-backups'${white}        |"
   hr
-  echo -e "| Klipper & API:             | Touchscreen GUI:         |"
-  echo -e "|  1) [Klipper]              |  7) [KlipperScreen]      |"
+  echo -e "| Klipper & API:             | Spool Manager:           |"
+  echo -e "|  1) [Klipper]              |  8) [Spoolman]           |"
   echo -e "|  2) [Moonraker]            |                          |"
   echo -e "|  3) [Config Folder]        | 3rd Party Webinterface:  |"
-  echo -e "|  4) [Moonraker Database]   |  8) [OctoPrint]          |"
+  echo -e "|  4) [Moonraker Database]   |  9) [OctoPrint]          |"
   echo -e "|                            |                          |"
   echo -e "| Klipper Webinterface:      | Other:                   |"
-  echo -e "|  5) [Mainsail]             |  9) [Telegram Bot]       |"
-  echo -e "|  6) [Fluidd]               | 10) [OctoEverywhere]     |"
+  echo -e "|  5) [Mainsail]             | 10) [Telegram Bot]       |"
+  echo -e "|  6) [Fluidd]               | 11) [OctoEverywhere]     |"
+  echo -e "|                            |                          |"
+  echo -e "| Touchscreen GUI:           |                          |"
+  echo -e "|  7) [KlipperScreen]        |                          |"
   back_footer
 }
 
@@ -51,10 +54,12 @@ function backup_menu() {
       7)
         do_action "backup_klipperscreen" "backup_ui";;
       8)
-        do_action "backup_octoprint" "backup_ui";;
+        do_action "backup_spoolman" "backup_ui";;
       9)
-        do_action "backup_telegram_bot" "backup_ui";;
+        do_action "backup_octoprint" "backup_ui";;
       10)
+        do_action "backup_telegram_bot" "backup_ui";;
+      11)
         do_action "backup_octoeverywhere" "backup_ui";;
       B|b)
         clear; main_menu; break;;

--- a/scripts/ui/backup_menu.sh
+++ b/scripts/ui/backup_menu.sh
@@ -17,18 +17,16 @@ function backup_ui() {
   hr
   echo -e "| ${yellow}INFO: Backups are located in '~/kiauh-backups'${white}        |"
   hr
-  echo -e "| Klipper & API:             | Spool Manager:           |"
-  echo -e "|  1) [Klipper]              |  8) [Spoolman]           |"
+  echo -e "| Klipper & API:             | Touchscreen GUI:         |"
+  echo -e "|  1) [Klipper]              |  7) [KlipperScreen]      |"
   echo -e "|  2) [Moonraker]            |                          |"
   echo -e "|  3) [Config Folder]        | 3rd Party Webinterface:  |"
-  echo -e "|  4) [Moonraker Database]   |  9) [OctoPrint]          |"
+  echo -e "|  4) [Moonraker Database]   |  8) [OctoPrint]          |"
   echo -e "|                            |                          |"
   echo -e "| Klipper Webinterface:      | Other:                   |"
-  echo -e "|  5) [Mainsail]             | 10) [Telegram Bot]       |"
-  echo -e "|  6) [Fluidd]               | 11) [OctoEverywhere]     |"
-  echo -e "|                            |                          |"
-  echo -e "| Touchscreen GUI:           |                          |"
-  echo -e "|  7) [KlipperScreen]        |                          |"
+  echo -e "|  5) [Mainsail]             |  9) [Telegram Bot]       |"
+  echo -e "|  6) [Fluidd]               | 10) [OctoEverywhere]     |"
+  echo -e "|                            | 11) [Spoolman]           |"
   back_footer
 }
 
@@ -54,13 +52,13 @@ function backup_menu() {
       7)
         do_action "backup_klipperscreen" "backup_ui";;
       8)
-        do_action "backup_spoolman" "backup_ui";;
-      9)
         do_action "backup_octoprint" "backup_ui";;
-      10)
+      9)
         do_action "backup_telegram_bot" "backup_ui";;
-      11)
+      10)
         do_action "backup_octoeverywhere" "backup_ui";;
+      11)
+        do_action "backup_spoolman" "backup_ui";;
       B|b)
         clear; main_menu; break;;
       *)

--- a/scripts/ui/install_menu.sh
+++ b/scripts/ui/install_menu.sh
@@ -19,19 +19,19 @@ function install_ui() {
   echo -e "|  all necessary dependencies for the various           |"
   echo -e "|  functions on a completely fresh system.              |"
   hr
-  echo -e "| Firmware & API:          | 3rd Party Webinterface:    |"
-  echo -e "|  1) [Klipper]            |  7) [OctoPrint]            |"
-  echo -e "|  2) [Moonraker]          |                            |"
-  echo -e "|                          | Other:                     |"
-  echo -e "| Klipper Webinterface:    |  8) [PrettyGCode]          |"
-  echo -e "|  3) [Mainsail]           |  9) [Telegram Bot]         |"
-  echo -e "|  4) [Fluidd]             | 10) $(obico_install_title) |"
-  echo -e "|                          | 11) [OctoEverywhere]       |"
-  echo -e "| Touchscreen GUI:         | 12) [Mobileraker]          |"
-  echo -e "|  5) [KlipperScreen]      | 13) [OctoApp for Klipper]  |"
-  echo -e "|                          |                            |"
-  echo -e "| Spool Manager:           | Webcam Streamer:           |"
-  echo -e "|  6) [Spoolman]           | 14) [Crowsnest]            |"
+  echo -e "| Firmware & API:          | Other:                     |"
+  echo -e "|  1) [Klipper]            |  7) [PrettyGCode]          |"
+  echo -e "|  2) [Moonraker]          |  8) [Telegram Bot]         |"
+  echo -e "|                          |  9) $(obico_install_title) |"
+  echo -e "| Klipper Webinterface:    | 10) [OctoEverywhere]       |"
+  echo -e "|  3) [Mainsail]           | 11) [Mobileraker]          |"
+  echo -e "|  4) [Fluidd]             | 12) [OctoApp for Klipper]  |"
+  echo -e "|                          | 13) [Spoolman]             |"
+  echo -e "| Touchscreen GUI:         |                            |"
+  echo -e "|  5) [KlipperScreen]      | Webcam Streamer:           |"
+  echo -e "|                          | 14) [Crowsnest]            |"
+  echo -e "| 3rd Party Webinterface:  |                            |"
+  echo -e "|  6) [OctoPrint]          |                            |"
   back_footer
 }
 
@@ -61,21 +61,21 @@ function install_menu() {
       5)
         do_action "install_klipperscreen" "install_ui";;
       6)
-        do_action "install_spoolman" "install_ui";;
-      7)
         do_action "octoprint_setup_dialog" "install_ui";;
-      8)
+      7)
         do_action "install_pgc_for_klipper" "install_ui";;
-      9)
+      8)
         do_action "telegram_bot_setup_dialog" "install_ui";;
-      10)
+      9)
         do_action "moonraker_obico_setup_dialog" "install_ui";;
-      11)
+      10)
         do_action "octoeverywhere_setup_dialog" "install_ui";;
-      12)
+      11)
         do_action "install_mobileraker" "install_ui";;
-      13)
+      12)
         do_action "octoapp_setup_dialog" "install_ui";;
+      13)
+        do_action "install_spoolman" "install_ui";;
       14)
         do_action "install_crowsnest" "install_ui";;
       B|b)

--- a/scripts/ui/install_menu.sh
+++ b/scripts/ui/install_menu.sh
@@ -20,18 +20,18 @@ function install_ui() {
   echo -e "|  functions on a completely fresh system.              |"
   hr
   echo -e "| Firmware & API:          | 3rd Party Webinterface:    |"
-  echo -e "|  1) [Klipper]            |  6) [OctoPrint]            |"
+  echo -e "|  1) [Klipper]            |  7) [OctoPrint]            |"
   echo -e "|  2) [Moonraker]          |                            |"
   echo -e "|                          | Other:                     |"
-  echo -e "| Klipper Webinterface:    |  7) [PrettyGCode]          |"
-  echo -e "|  3) [Mainsail]           |  8) [Telegram Bot]         |"
-  echo -e "|  4) [Fluidd]             |  9) $(obico_install_title) |"
-  echo -e "|                          | 10) [OctoEverywhere]       |"
-  echo -e "|                          | 11) [Mobileraker]          |"
-  echo -e "| Touchscreen GUI:         | 12) [OctoApp for Klipper]  |"
-  echo -e "|  5) [KlipperScreen]      |                            |"
-  echo -e "|                          | Webcam Streamer:           |"
-  echo -e "|                          | 13) [Crowsnest]            |"
+  echo -e "| Klipper Webinterface:    |  8) [PrettyGCode]          |"
+  echo -e "|  3) [Mainsail]           |  9) [Telegram Bot]         |"
+  echo -e "|  4) [Fluidd]             | 10) $(obico_install_title) |"
+  echo -e "|                          | 11) [OctoEverywhere]       |"
+  echo -e "| Touchscreen GUI:         | 12) [Mobileraker]          |"
+  echo -e "|  5) [KlipperScreen]      | 13) [OctoApp for Klipper]  |"
+  echo -e "|                          |                            |"
+  echo -e "| Spool Manager:           | Webcam Streamer:           |"
+  echo -e "|  6) [Spoolman]           | 14) [Crowsnest]            |"
   back_footer
 }
 
@@ -61,20 +61,22 @@ function install_menu() {
       5)
         do_action "install_klipperscreen" "install_ui";;
       6)
-        do_action "octoprint_setup_dialog" "install_ui";;
+        do_action "install_spoolman" "install_ui";;
       7)
-        do_action "install_pgc_for_klipper" "install_ui";;
+        do_action "octoprint_setup_dialog" "install_ui";;
       8)
-        do_action "telegram_bot_setup_dialog" "install_ui";;
+        do_action "install_pgc_for_klipper" "install_ui";;
       9)
-        do_action "moonraker_obico_setup_dialog" "install_ui";;
+        do_action "telegram_bot_setup_dialog" "install_ui";;
       10)
-        do_action "octoeverywhere_setup_dialog" "install_ui";;
+        do_action "moonraker_obico_setup_dialog" "install_ui";;
       11)
-        do_action "install_mobileraker" "install_ui";;
+        do_action "octoeverywhere_setup_dialog" "install_ui";;
       12)
-        do_action "octoapp_setup_dialog" "install_ui";;
+        do_action "install_mobileraker" "install_ui";;
       13)
+        do_action "octoapp_setup_dialog" "install_ui";;
+      14)
         do_action "install_crowsnest" "install_ui";;
       B|b)
         clear; main_menu; break;;

--- a/scripts/ui/main_menu.sh
+++ b/scripts/ui/main_menu.sh
@@ -29,6 +29,7 @@ function main_ui() {
   echo -e "|                  |  OctoEverywhere: $(print_status "octoeverywhere")|"
   echo -e "|                  |     Mobileraker: $(print_status "mobileraker")|"
   echo -e "|                  |         OctoApp: $(print_status "octoapp")|"
+  echo -e "|                  |        Spoolman: $(print_status "spoolman")|"
   echo -e "|                  |                                    |"
   echo -e "|                  |       Octoprint: $(print_status "octoprint")|"
   hr

--- a/scripts/ui/remove_menu.sh
+++ b/scripts/ui/remove_menu.sh
@@ -17,21 +17,21 @@ function remove_ui() {
   hr
   echo -e "| ${yellow}INFO: Configurations and/or any backups will be kept!${white} |"
   hr
-  echo -e "| Firmware & API:           | 3rd Party Webinterface:   |"
-  echo -e "|  1) [Klipper]             |  9) [OctoPrint]           |"
-  echo -e "|  2) [Moonraker]           |                           |"
-  echo -e "|                           | Webcam Streamer:          |"
-  echo -e "| Klipper Webinterface:     | 10) [Crowsnest]           |"
-  echo -e "|  3) [Mainsail]            | 11) [MJPG-Streamer]       |"
-  echo -e "|  4) [Mainsail-Config]     |                           |"
-  echo -e "|  5) [Fluidd]              | Other:                    |"
-  echo -e "|  6) [Fluidd-Config]       | 12) [PrettyGCode]         |"
-  echo -e "|                           | 13) [Telegram Bot]        |"
-  echo -e "| Touchscreen GUI:          | 14) [Obico for Klipper]   |"
-  echo -e "|  7) [KlipperScreen]       | 15) [OctoEverywhere]      |"
-  echo -e "|                           | 16) [Mobileraker]         |"
-  echo -e "| Spool Manager:            | 17) [NGINX]               |"
-  echo -e "|  8) [Spoolman]            | 18) [OctoApp]             |"
+  echo -e "| Firmware & API:           | Webcam Streamer:          |"
+  echo -e "|  1) [Klipper]             |  9) [Crowsnest]           |"
+  echo -e "|  2) [Moonraker]           | 10) [MJPG-Streamer]       |"
+  echo -e "|                           |                           |"
+  echo -e "| Klipper Webinterface:     | Other:                    |"
+  echo -e "|  3) [Mainsail]            | 11) [PrettyGCode]         |"
+  echo -e "|  4) [Mainsail-Config]     | 12) [Telegram Bot]        |"
+  echo -e "|  5) [Fluidd]              | 13) [Obico for Klipper]   |"
+  echo -e "|  6) [Fluidd-Config]       | 14) [OctoEverywhere]      |"
+  echo -e "|                           | 15) [Mobileraker]         |"
+  echo -e "| Touchscreen GUI:          | 16) [NGINX]               |"
+  echo -e "|  7) [KlipperScreen]       | 17) [OctoApp]             |"
+  echo -e "|                           | 18) [Spoolman]             |"
+  echo -e "| 3rd Party Webinterface:   |                           |"
+  echo -e "|  8) [OctoPrint]           |                           |"
   back_footer
 }
 
@@ -57,27 +57,27 @@ function remove_menu() {
       7)
         do_action "remove_klipperscreen" "remove_ui";;
       8)
-        do_action "remove_spoolman" "remove_ui";;
-      9)
         do_action "remove_octoprint" "remove_ui";;
-      10)
+      9)
         do_action "remove_crowsnest" "remove_ui";;
-      11)
+      10)
         do_action "remove_mjpg-streamer" "remove_ui";;
-      12)
+      11)
         do_action "remove_prettygcode" "remove_ui";;
-      13)
+      12)
         do_action "remove_telegram_bot" "remove_ui";;
-      14)
+      13)
         do_action "remove_moonraker_obico" "remove_ui";;
-      15)
+      14)
         do_action "remove_octoeverywhere" "remove_ui";;
-      16)
+      15)
         do_action "remove_mobileraker" "remove_ui";;
-      17)
+      16)
         do_action "remove_nginx" "remove_ui";;
-      18)
+      17)
         do_action "remove_octoapp" "remove_ui";;
+      18)
+        do_action "remove_spoolman" "remove_ui";;
       B|b)
         clear; main_menu; break;;
       *)

--- a/scripts/ui/remove_menu.sh
+++ b/scripts/ui/remove_menu.sh
@@ -18,20 +18,20 @@ function remove_ui() {
   echo -e "| ${yellow}INFO: Configurations and/or any backups will be kept!${white} |"
   hr
   echo -e "| Firmware & API:           | 3rd Party Webinterface:   |"
-  echo -e "|  1) [Klipper]             |  8) [OctoPrint]           |"
+  echo -e "|  1) [Klipper]             |  9) [OctoPrint]           |"
   echo -e "|  2) [Moonraker]           |                           |"
   echo -e "|                           | Webcam Streamer:          |"
-  echo -e "| Klipper Webinterface:     |  9) [Crowsnest]           |"
-  echo -e "|  3) [Mainsail]            | 10) [MJPG-Streamer]       |"
+  echo -e "| Klipper Webinterface:     | 10) [Crowsnest]           |"
+  echo -e "|  3) [Mainsail]            | 11) [MJPG-Streamer]       |"
   echo -e "|  4) [Mainsail-Config]     |                           |"
   echo -e "|  5) [Fluidd]              | Other:                    |"
-  echo -e "|  6) [Fluidd-Config]       | 11) [PrettyGCode]         |"
-  echo -e "|                           | 12) [Telegram Bot]        |"
-  echo -e "| Touchscreen GUI:          | 13) [Obico for Klipper]   |"
-  echo -e "|  7) [KlipperScreen]       | 14) [OctoEverywhere]      |"
-  echo -e "|                           | 15) [Mobileraker]         |"
-  echo -e "|                           | 16) [NGINX]               |"
-  echo -e "|                           | 17) [OctoApp]             |"
+  echo -e "|  6) [Fluidd-Config]       | 12) [PrettyGCode]         |"
+  echo -e "|                           | 13) [Telegram Bot]        |"
+  echo -e "| Touchscreen GUI:          | 14) [Obico for Klipper]   |"
+  echo -e "|  7) [KlipperScreen]       | 15) [OctoEverywhere]      |"
+  echo -e "|                           | 16) [Mobileraker]         |"
+  echo -e "| Spool Manager:            | 17) [NGINX]               |"
+  echo -e "|  8) [Spoolman]            | 18) [OctoApp]             |"
   back_footer
 }
 
@@ -57,24 +57,26 @@ function remove_menu() {
       7)
         do_action "remove_klipperscreen" "remove_ui";;
       8)
-        do_action "remove_octoprint" "remove_ui";;
+        do_action "remove_spoolman" "remove_ui";;
       9)
-        do_action "remove_crowsnest" "remove_ui";;
+        do_action "remove_octoprint" "remove_ui";;
       10)
-        do_action "remove_mjpg-streamer" "remove_ui";;
+        do_action "remove_crowsnest" "remove_ui";;
       11)
-        do_action "remove_prettygcode" "remove_ui";;
+        do_action "remove_mjpg-streamer" "remove_ui";;
       12)
-        do_action "remove_telegram_bot" "remove_ui";;
+        do_action "remove_prettygcode" "remove_ui";;
       13)
-        do_action "remove_moonraker_obico" "remove_ui";;
+        do_action "remove_telegram_bot" "remove_ui";;
       14)
-        do_action "remove_octoeverywhere" "remove_ui";;
+        do_action "remove_moonraker_obico" "remove_ui";;
       15)
-        do_action "remove_mobileraker" "remove_ui";;
+        do_action "remove_octoeverywhere" "remove_ui";;
       16)
-        do_action "remove_nginx" "remove_ui";;
+        do_action "remove_mobileraker" "remove_ui";;
       17)
+        do_action "remove_nginx" "remove_ui";;
+      18)
         do_action "remove_octoapp" "remove_ui";;
       B|b)
         clear; main_menu; break;;

--- a/scripts/ui/update_menu.sh
+++ b/scripts/ui/update_menu.sh
@@ -28,23 +28,26 @@ function update_ui() {
   echo -e "| Touchscreen GUI:       |---------------|--------------|"
   echo -e "|  5) [KlipperScreen]    |$(compare_klipperscreen_versions)|"
   echo -e "|                        |               |              |"
+  echo -e "| Spool Manager:         |---------------|--------------|"
+  echo -e "|  6) [Spoolman]         |$(compare_spoolman_versions)|"
+  echo -e "|                        |               |              |"
   echo -e "| Other:                 |---------------|--------------|"
-  echo -e "|  6) [PrettyGCode]      |$(compare_prettygcode_versions)|"
-  echo -e "|  7) [Telegram Bot]     |$(compare_telegram_bot_versions)|"
-  echo -e "|  8) [Obico for Klipper]|$(compare_moonraker_obico_versions)|"
-  echo -e "|  9) [OctoEverywhere]   |$(compare_octoeverywhere_versions)|"
-  echo -e "| 10) [Mobileraker]      |$(compare_mobileraker_versions)|"
-  echo -e "| 11) [Crowsnest]        |$(compare_crowsnest_versions)|"
-  echo -e "| 12) [OctoApp]          |$(compare_octoapp_versions)|"
+  echo -e "|  7) [PrettyGCode]      |$(compare_prettygcode_versions)|"
+  echo -e "|  8) [Telegram Bot]     |$(compare_telegram_bot_versions)|"
+  echo -e "|  9) [Obico for Klipper]|$(compare_moonraker_obico_versions)|"
+  echo -e "| 10) [OctoEverywhere]   |$(compare_octoeverywhere_versions)|"
+  echo -e "| 11) [Mobileraker]      |$(compare_mobileraker_versions)|"
+  echo -e "| 12) [Crowsnest]        |$(compare_crowsnest_versions)|"
+  echo -e "| 13) [OctoApp]          |$(compare_octoapp_versions)|"
   echo -e "|                        |------------------------------|"
-  echo -e "| 13) [System]           |  $(check_system_updates)   |"
+  echo -e "| 14) [System]           |  $(check_system_updates)   |"
   back_footer
 }
 
 function update_menu() {
   clear -x && sudo true && clear -x # (re)cache sudo credentials so password prompt doesn't bork ui
   do_action "" "update_ui"
-  
+
   local action
   while true; do
     read -p "${cyan}####### Perform action:${white} " action
@@ -62,20 +65,22 @@ function update_menu() {
       5)
         do_action "update_klipperscreen" "update_ui";;
       6)
-        do_action "update_pgc_for_klipper" "update_ui";;
+        do_action "update_spoolman" "update_ui";;
       7)
-        do_action "update_telegram_bot" "update_ui";;
+        do_action "update_pgc_for_klipper" "update_ui";;
       8)
-        do_action "update_moonraker_obico" "update_ui";;
+        do_action "update_telegram_bot" "update_ui";;
       9)
-        do_action "update_octoeverywhere" "update_ui";;
+        do_action "update_moonraker_obico" "update_ui";;
       10)
-        do_action "update_mobileraker" "update_ui";;
+        do_action "update_octoeverywhere" "update_ui";;
       11)
-        do_action "update_crowsnest" "update_ui";;
+        do_action "update_mobileraker" "update_ui";;
       12)
-        do_action "update_octoapp" "update_ui";;
+        do_action "update_crowsnest" "update_ui";;
       13)
+        do_action "update_octoapp" "update_ui";;
+      14)
         do_action "upgrade_system_packages" "update_ui";;
       a)
         do_action "update_all" "update_ui";;
@@ -101,7 +106,7 @@ function update_all() {
       print_confirm "Everything is already up-to-date!"
       echo; break
     fi
-    
+
     echo
     top_border
     echo -e "|  The following installations will be updated:         |"
@@ -120,6 +125,9 @@ function update_all() {
 
     [[ "${update_arr[*]}" =~ "klipperscreen" ]] && \
     echo -e "|  ${cyan}● KlipperScreen${white}                                      |"
+
+    [[ "${update_arr[*]}" =~ "spoolman" ]] && \
+    echo -e "|  ${cyan}● SpoolMan${white}                                      |"
 
     [[ "${update_arr[*]}" =~ "pgc_for_klipper" ]] && \
     echo -e "|  ${cyan}● PrettyGCode for Klipper${white}                            |"
@@ -140,7 +148,7 @@ function update_all() {
     echo -e "|  ${cyan}● System${white}                                             |"
 
     bottom_border
-    
+
     local yn
     read -p "${cyan}###### Do you want to proceed? (Y/n):${white} " yn
     case "${yn}" in

--- a/scripts/ui/update_menu.sh
+++ b/scripts/ui/update_menu.sh
@@ -28,17 +28,15 @@ function update_ui() {
   echo -e "| Touchscreen GUI:       |---------------|--------------|"
   echo -e "|  5) [KlipperScreen]    |$(compare_klipperscreen_versions)|"
   echo -e "|                        |               |              |"
-  echo -e "| Spool Manager:         |---------------|--------------|"
-  echo -e "|  6) [Spoolman]         |$(compare_spoolman_versions)|"
-  echo -e "|                        |               |              |"
   echo -e "| Other:                 |---------------|--------------|"
-  echo -e "|  7) [PrettyGCode]      |$(compare_prettygcode_versions)|"
-  echo -e "|  8) [Telegram Bot]     |$(compare_telegram_bot_versions)|"
-  echo -e "|  9) [Obico for Klipper]|$(compare_moonraker_obico_versions)|"
-  echo -e "| 10) [OctoEverywhere]   |$(compare_octoeverywhere_versions)|"
-  echo -e "| 11) [Mobileraker]      |$(compare_mobileraker_versions)|"
-  echo -e "| 12) [Crowsnest]        |$(compare_crowsnest_versions)|"
-  echo -e "| 13) [OctoApp]          |$(compare_octoapp_versions)|"
+  echo -e "|  6) [PrettyGCode]      |$(compare_prettygcode_versions)|"
+  echo -e "|  7) [Telegram Bot]     |$(compare_telegram_bot_versions)|"
+  echo -e "|  8) [Obico for Klipper]|$(compare_moonraker_obico_versions)|"
+  echo -e "|  9) [OctoEverywhere]   |$(compare_octoeverywhere_versions)|"
+  echo -e "| 10) [Mobileraker]      |$(compare_mobileraker_versions)|"
+  echo -e "| 11) [Crowsnest]        |$(compare_crowsnest_versions)|"
+  echo -e "| 12) [OctoApp]          |$(compare_octoapp_versions)|"
+  echo -e "| 13) [Spoolman]         |$(compare_spoolman_versions)|"
   echo -e "|                        |------------------------------|"
   echo -e "| 14) [System]           |  $(check_system_updates)   |"
   back_footer
@@ -65,21 +63,21 @@ function update_menu() {
       5)
         do_action "update_klipperscreen" "update_ui";;
       6)
-        do_action "update_spoolman" "update_ui";;
-      7)
         do_action "update_pgc_for_klipper" "update_ui";;
-      8)
+      7)
         do_action "update_telegram_bot" "update_ui";;
-      9)
+      8)
         do_action "update_moonraker_obico" "update_ui";;
-      10)
+      9)
         do_action "update_octoeverywhere" "update_ui";;
-      11)
+      10)
         do_action "update_mobileraker" "update_ui";;
-      12)
+      11)
         do_action "update_crowsnest" "update_ui";;
-      13)
+      12)
         do_action "update_octoapp" "update_ui";;
+      13)
+        do_action "update_spoolman" "update_ui";;
       14)
         do_action "upgrade_system_packages" "update_ui";;
       a)


### PR DESCRIPTION
Hello, this PR adds support (install, update, remove, backup) for [Spoolman](https://github.com/Donkie/Spoolman) as it was requested in #373.

---

### Main outline
- The install script follows the [Spoolman docs](https://github.com/Donkie/Spoolman/blob/master/README.md#:~:text=sudo%20apt%2Dget,scripts/install.sh) and it has support for advanced configuration (only for the server's port at the moment)
- The update script follows the [Spoolman docs](https://github.com/Donkie/Spoolman/blob/master/README.md#:~:text=%23%20Stop%20and,rm%20%2Drf%20../Spoolman_old)
- The remove script deletes the Spoolman dir as well as the dir containing the SQLite db, cache and logs located by default in `~/.local/share/spoolman`
- The backup script copies both the Spoolman dir and the `~/.local/share/spoolman` into kiauh's backup dir

### Possible problems and thing to keep in mind
- I've tested the installation with python 3.9 through 3.12: every version installs correctly other than python 3.12, there seems to be some problem when it tries to build wheels for [greenlet](https://github.com/python-greenlet/greenlet) (which seems to already have an open issue python-greenlet/greenlet#406) and uvloop. I could add a check and a warning for the python version to the install script, let me know what you think
- As said above in the outline section the advanced configuration only allows to edit the server's port for now, the addition of more configuration steps (like external db servers as suggested in #373 (which I might implement in the future)) should be pretty straight forward by adding them to the `advanced_config` function

Of course let me know if something needs changing or improving 