### PR TITLE
fix: replace jq by grep to check Spoolman update

### DIFF
--- a/scripts/spoolman.sh
+++ b/scripts/spoolman.sh
@@ -248,13 +248,17 @@ function get_spoolman_status() {
 
 function get_local_spoolman_version() {
   local version
-  version=$(jq -r '.version' "${SPOOLMAN_DIR}"/release_info.json)
+  if [[ -d "${SPOOLMAN_DIR}" ]]; then
+    version=$(grep -o '"version":\s*"[^"]*' "${SPOOLMAN_DIR}"/release_info.json | cut -d'"' -f4)
+  else
+    version=""
+  fi
   echo "${version}"
 }
 
 function get_remote_spoolman_version() {
   local version
-  version=$(curl -s "${SPOOLMAN_REPO}" | jq -r '.tag_name')
+  version=$(curl -s "${SPOOLMAN_REPO}" | grep -o '"tag_name":\s*"v[^"]*"' | cut -d'"' -f4)
   echo "${version}"
 }
 

--- a/scripts/ui/remove_menu.sh
+++ b/scripts/ui/remove_menu.sh
@@ -29,7 +29,7 @@ function remove_ui() {
   echo -e "|                           | 15) [Mobileraker]         |"
   echo -e "| Touchscreen GUI:          | 16) [NGINX]               |"
   echo -e "|  7) [KlipperScreen]       | 17) [OctoApp]             |"
-  echo -e "|                           | 18) [Spoolman]             |"
+  echo -e "|                           | 18) [Spoolman]            |"
   echo -e "| 3rd Party Webinterface:   |                           |"
   echo -e "|  8) [OctoPrint]           |                           |"
   back_footer


### PR DESCRIPTION
This PR fixes the issues reported by @dimitrisch in #477.

### Changes:
- `jq` has been replaced by `grep` using a regex to retrieve the local and remote Spoolman versions
- removed an extra space in the remove menu 

