### PR TITLE
fix: parse moonraker dependencies from system-dependencies.json

### DIFF
--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -142,12 +142,12 @@ function moonraker_setup_dialog() {
 
 function install_moonraker_dependencies() {
   local packages log_name="Moonraker"
-  local install_script="${MOONRAKER_DIR}/scripts/install-moonraker.sh"
+  local package_json="${MOONRAKER_DIR}/scripts/system-dependencies.json"
 
   ### read PKGLIST from official install-script
   status_msg "Reading dependencies..."
   # shellcheck disable=SC2016
-  packages="$(grep "PKGLIST=" "${install_script}" | cut -d'"' -f2 | sed 's/\${PKGLIST}//g' | tr -d '\n')"
+  packages=$(cat $package_json | tr -d ' \n{}' | cut -d "]" -f1 | cut -d":" -f2 | tr -d '"[' | sed 's/,/ /g')
 
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"


### PR DESCRIPTION
A recent moonraker update broke KIAUHs parsing capabilities for the system dependencies.
This PR will fix the parsing and uses a different file for parsing the dependencies.
As soon as more distros are added to the file, this method needs to be checked again.

Fixes #489 