### PR TITLE
refactor: add check for (service|timer) to sys_utils

### DIFF
--- a/kiauh/utils/sys_utils.py
+++ b/kiauh/utils/sys_utils.py
@@ -409,7 +409,7 @@ def service_instance_exists(name: str, exclude: List[str] | None = None) -> bool
     :return: True if the service exists, False otherwise
     """
     exclude = exclude or []
-    pattern = re.compile(f"^{name}(-[0-9a-zA-Z]+)?.service$")
+    pattern = re.compile(f"^{name}(-[0-9a-zA-Z]+)?\.(service|timer)$")
     service_list = [
         Path(SYSTEMD, service)
         for service in SYSTEMD.iterdir()


### PR DESCRIPTION
It is [also possible](https://wiki.archlinux.org/title/Systemd/Timers) to create timer files with systemd. Like other systemd files, these are located under `/etc/systemd/system` and must end with `.timer`. This PR makes it possible to check for such files.