### PR TITLE
fix: remove "obico" from the suffix_blacklist so that it can discover its own instances.

### DIFF
--- a/kiauh/extensions/obico/moonraker_obico_extension.py
+++ b/kiauh/extensions/obico/moonraker_obico_extension.py
@@ -12,6 +12,7 @@ from typing import List
 from components.klipper.klipper import Klipper
 from components.moonraker.moonraker import Moonraker
 from core.instance_manager.instance_manager import InstanceManager
+from core.instance_manager.base_instance import SUFFIX_BLACKLIST
 from core.logger import DialogType, Logger
 from core.submodules.simple_config_parser.src.simple_config_parser.simple_config_parser import (
     SimpleConfigParser,
@@ -308,7 +309,8 @@ class ObicoExtension(BaseExtension):
     def _check_and_opt_link_instances(self) -> None:
         Logger.print_status("Checking link status of Obico instances ...")
 
-        ob_instances: List[MoonrakerObico] = get_instances(MoonrakerObico)
+        suffix_blacklist: List[str] = [suffix for suffix in SUFFIX_BLACKLIST if suffix != 'obico']
+        ob_instances: List[MoonrakerObico] = get_instances(MoonrakerObico, suffix_blacklist=suffix_blacklist)
         unlinked_instances: List[MoonrakerObico] = [
             obico for obico in ob_instances if not obico.is_linked
         ]

--- a/kiauh/utils/instance_utils.py
+++ b/kiauh/utils/instance_utils.py
@@ -17,7 +17,7 @@ from core.instance_manager.base_instance import SUFFIX_BLACKLIST
 from utils.instance_type import InstanceType
 
 
-def get_instances(instance_type: type) -> List[InstanceType]:
+def get_instances(instance_type: type, suffix_blacklist: List[str] = SUFFIX_BLACKLIST) -> List[InstanceType]:
     from utils.common import convert_camelcase_to_kebabcase
 
     if not isinstance(instance_type, type):
@@ -30,7 +30,7 @@ def get_instances(instance_type: type) -> List[InstanceType]:
         Path(SYSTEMD, service)
         for service in SYSTEMD.iterdir()
         if pattern.search(service.name)
-        and not any(s in service.name for s in SUFFIX_BLACKLIST)
+        and not any(s in service.name for s in suffix_blacklist)
     ]
 
     instance_list = [


### PR DESCRIPTION
As discussed in discord chat with @dw-0 , suffix "obico" needs to be removed from the blacklist so that moonraker_obico_extension can discover itself when calling get_instances.