### PR TITLE
fix: self.cfg_file is already a full path

### DIFF
--- a/kiauh/extensions/obico/moonraker_obico.py
+++ b/kiauh/extensions/obico/moonraker_obico.py
@@ -132,7 +132,7 @@ class MoonrakerObico:
             raise
         env_file_content = env_template_file_content.replace(
             "%CFG%",
-            f"{self.base.cfg_dir}/{self.cfg_file}",
+            f"{self.cfg_file}",
         )
         return env_file_content
 


### PR DESCRIPTION
Without this fix, the `/home/pi/printer_data/systemd/moonraker-obico.env` would be generated as:

```
OBICO_ARGS="-m moonraker_obico.app -c /home/pi/printer_data/config//home/pi/printer_data/config/moonraker-obico.cfg"
```