### PR TITLE
Add client name to Moonraker not found dialog

### DIFF
--- a/kiauh/components/webui_client/client_dialogs.py
+++ b/kiauh/components/webui_client/client_dialogs.py
@@ -13,15 +13,15 @@ from components.webui_client.base_data import BaseWebClient
 from core.logger import DialogType, Logger
 
 
-def print_moonraker_not_found_dialog() -> None:
+def print_moonraker_not_found_dialog(name: str) -> None:
     Logger.print_dialog(
         DialogType.WARNING,
         [
             "No local Moonraker installation was found!",
             "\n\n",
-            "It is possible to install Mainsail without a local Moonraker installation. "
+            f"It is possible to install {name} without a local Moonraker installation. "
             "If you continue, you need to make sure, that Moonraker is installed on "
-            "another machine in your network. Otherwise Mainsail will NOT work "
+            f"another machine in your network. Otherwise {name} will NOT work "
             "correctly.",
         ],
     )

--- a/kiauh/components/webui_client/client_setup.py
+++ b/kiauh/components/webui_client/client_setup.py
@@ -67,7 +67,7 @@ def install_client(client: BaseWebClient) -> None:
 
     enable_remotemode = False
     if not mr_instances:
-        print_moonraker_not_found_dialog()
+        print_moonraker_not_found_dialog(client.display_name)
         if not get_confirm(f"Continue {client.display_name} installation?"):
             return
 


### PR DESCRIPTION
Makes the client name on the "Moonraker not found" dynamic so it correctly indicates the client the user is trying to install.