### PR TITLE
feat(git_utils): Support for blolbless clone mode in git_cmd_clone

### DIFF
--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -133,7 +133,7 @@ def get_local_tags(repo_path: Path, _filter: str | None = None) -> List[str]:
         tags: List[str] = result.split("\n")[:-1]
 
         return sorted(tags, key=lambda x: [int(i) if i.isdigit() else i for i in
-                                            re.split(r'(\d+)', x)])
+                                                re.split(r'(\d+)', x)])
 
     except CalledProcessError:
         return []

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -81,8 +81,10 @@ def get_repo_name(repo: Path) -> Tuple[str, str]:
         return "-", "-"
 
     try:
-        cmd = ["git", "-C", repo.as_posix(), "config", "--get", "remote.origin.url"]
-        result: str = check_output(cmd, stderr=DEVNULL).decode(encoding="utf-8")
+        cmd = ["git", "-C", repo.as_posix(), "config", "--get",
+               "remote.origin.url"]
+        result: str = check_output(
+            cmd, stderr=DEVNULL).decode(encoding="utf-8")
         substrings: List[str] = result.strip().split("/")[-2:]
 
         orga: str = substrings[0] if substrings[0] else "-"
@@ -133,7 +135,7 @@ def get_local_tags(repo_path: Path, _filter: str | None = None) -> List[str]:
         tags: List[str] = result.split("\n")[:-1]
 
         return sorted(tags, key=lambda x: [int(i) if i.isdigit() else i for i in
-                                                re.split(r'(\d+)', x)])
+                                           re.split(r'(\d+)', x)])
 
     except CalledProcessError:
         return []
@@ -185,7 +187,8 @@ def get_latest_unstable_tag(repo_path: str) -> str:
     """
     try:
         if (
-            len(unstable_tags := [t for t in get_remote_tags(repo_path) if "-" in t])
+            len(unstable_tags := [
+                t for t in get_remote_tags(repo_path) if "-" in t])
             > 0
         ):
             return unstable_tags[0]
@@ -253,31 +256,24 @@ def get_remote_commit(repo: Path) -> str | None:
         return None
 
 
-def git_cmd_clone(repo: str, target_dir: Path, depth: int = 0, single_branch: bool = False) -> None:
+def git_cmd_clone(repo: str, target_dir: Path, blolbless: bool = False) -> None:
     """
-    Clones a repository with optional depth and single-branch parameters.
+    Clones a repository with optional blolbless clone.
 
     :param repo: URL of the repository to clone.
     :param target_dir: Path where the repository will be cloned.
-    :param depth: Clone depth. If 0, the depth option will be omitted.
-    :param single_branch: Clone only a single branch if True.
-    :return: None
+    :param blolbless: If True, perform a blolbless clone by adding the '--blolbless' flag.
     """
     try:
         command = ["git", "clone"]
 
-        # Add --depth flag if depth > 0
-        if depth > 0:
-            command += ["--depth", str(depth)]
-
-        # Add --single-branch flag if single_branch is True
-        if single_branch:
-            command.append("--single-branch")
+        # Добавляем флаг для blolbless clone, если требуется
+        if blolbless:
+            command.append("--blolbless")
 
         command += [repo, target_dir.as_posix()]
 
         run(command, check=True)
-
         Logger.print_ok("Clone successful!")
     except CalledProcessError as e:
         error = e.stderr.decode() if e.stderr else "Unknown error"
@@ -317,7 +313,8 @@ def rollback_repository(repo_dir: Path, instance: Type[InstanceType]) -> None:
 
     instances = get_instances(instance)
 
-    Logger.print_warn("Do not continue if you have ongoing prints!", start="\n")
+    Logger.print_warn(
+        "Do not continue if you have ongoing prints!", start="\n")
     Logger.print_warn(
         f"All currently running {instance.__name__} services will be stopped!"
     )

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -263,6 +263,7 @@ def git_cmd_clone(repo: str, target_dir: Path, depth: int = 1) -> None:
             target_dir.as_posix()
         ]
         run(command, check=True)
+
         Logger.print_ok("Clone successful!")
     except CalledProcessError as e:
         error = e.stderr.decode() if e.stderr else "Unknown error"

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -253,15 +253,29 @@ def get_remote_commit(repo: Path) -> str | None:
         return None
 
 
-def git_cmd_clone(repo: str, target_dir: Path, depth: int = 1) -> None:
+def git_cmd_clone(repo: str, target_dir: Path, depth: int = 0, single_branch: bool = False) -> None:
+    """
+    Clones a repository with optional depth and single-branch parameters.
+
+    :param repo: URL of the repository to clone.
+    :param target_dir: Path where the repository will be cloned.
+    :param depth: Clone depth. If 0, the depth option will be omitted.
+    :param single_branch: Clone only a single branch if True.
+    :return: None
+    """
     try:
-        command = [
-            "git", "clone",
-            "--depth", str(depth),
-            "--single-branch",
-            repo,
-            target_dir.as_posix()
-        ]
+        command = ["git", "clone"]
+
+        # Add --depth flag if depth > 0
+        if depth > 0:
+            command += ["--depth", str(depth)]
+
+        # Add --single-branch flag if single_branch is True
+        if single_branch:
+            command.append("--single-branch")
+
+        command += [repo, target_dir.as_posix()]
+
         run(command, check=True)
 
         Logger.print_ok("Clone successful!")

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -81,10 +81,8 @@ def get_repo_name(repo: Path) -> Tuple[str, str]:
         return "-", "-"
 
     try:
-        cmd = ["git", "-C", repo.as_posix(), "config", "--get",
-               "remote.origin.url"]
-        result: str = check_output(
-            cmd, stderr=DEVNULL).decode(encoding="utf-8")
+        cmd = ["git", "-C", repo.as_posix(), "config", "--get", "remote.origin.url"]
+        result: str = check_output(cmd, stderr=DEVNULL).decode(encoding="utf-8")
         substrings: List[str] = result.strip().split("/")[-2:]
 
         orga: str = substrings[0] if substrings[0] else "-"
@@ -135,7 +133,7 @@ def get_local_tags(repo_path: Path, _filter: str | None = None) -> List[str]:
         tags: List[str] = result.split("\n")[:-1]
 
         return sorted(tags, key=lambda x: [int(i) if i.isdigit() else i for i in
-                                           re.split(r'(\d+)', x)])
+                                            re.split(r'(\d+)', x)])
 
     except CalledProcessError:
         return []

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -253,19 +253,19 @@ def get_remote_commit(repo: Path) -> str | None:
         return None
 
 
-def git_cmd_clone(repo: str, target_dir: Path, blolbless: bool = False) -> None:
+def git_cmd_clone(repo: str, target_dir: Path, blobless: bool = False) -> None:
     """
-    Clones a repository with optional blolbless clone.
+    Clones a repository with optional blobless clone.
 
     :param repo: URL of the repository to clone.
     :param target_dir: Path where the repository will be cloned.
-    :param blolbless: If True, perform a blolbless clone by adding the '--blolbless' flag.
+    :param blobless: If True, perform a blobless clone by adding the '--filter=blob:none' flag.
     """
     try:
         command = ["git", "clone"]
 
-        if blolbless:
-            command.append("--blolbless")
+        if blobless:
+            command.append("--filter=blob:none")
 
         command += [repo, target_dir.as_posix()]
 

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -253,11 +253,16 @@ def get_remote_commit(repo: Path) -> str | None:
         return None
 
 
-def git_cmd_clone(repo: str, target_dir: Path) -> None:
+def git_cmd_clone(repo: str, target_dir: Path, depth: int = 1) -> None:
     try:
-        command = ["git", "clone", repo, target_dir.as_posix()]
+        command = [
+            "git", "clone",
+            "--depth", str(depth),
+            "--single-branch",
+            repo,
+            target_dir.as_posix()
+        ]
         run(command, check=True)
-
         Logger.print_ok("Clone successful!")
     except CalledProcessError as e:
         error = e.stderr.decode() if e.stderr else "Unknown error"

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -185,8 +185,7 @@ def get_latest_unstable_tag(repo_path: str) -> str:
     """
     try:
         if (
-            len(unstable_tags := [
-                t for t in get_remote_tags(repo_path) if "-" in t])
+            len(unstable_tags := [t for t in get_remote_tags(repo_path) if "-" in t])
             > 0
         ):
             return unstable_tags[0]
@@ -265,7 +264,6 @@ def git_cmd_clone(repo: str, target_dir: Path, blolbless: bool = False) -> None:
     try:
         command = ["git", "clone"]
 
-        # Добавляем флаг для blolbless clone, если требуется
         if blolbless:
             command.append("--blolbless")
 
@@ -311,8 +309,7 @@ def rollback_repository(repo_dir: Path, instance: Type[InstanceType]) -> None:
 
     instances = get_instances(instance)
 
-    Logger.print_warn(
-        "Do not continue if you have ongoing prints!", start="\n")
+    Logger.print_warn("Do not continue if you have ongoing prints!", start="\n")
     Logger.print_warn(
         f"All currently running {instance.__name__} services will be stopped!"
     )

--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -26,9 +26,10 @@ def git_clone_wrapper(
 ) -> None:
     """
     Clones a repository from the given URL and checks out the specified branch if given.
+    The clone will be performed with the '--filter=blob:none' flag to perform a blobless clone.
 
     :param repo: The URL of the repository to clone.
-    :param branch: The branch to check out. If None, the default branch will be checked out.
+    :param branch: The branch to check out. If None, master or main, no checkout will be performed.
     :param target_dir: The directory where the repository will be cloned.
     :param force: Force the cloning of the repository even if it already exists.
     :return: None
@@ -43,8 +44,11 @@ def git_clone_wrapper(
                 return
             shutil.rmtree(target_dir)
 
-        git_cmd_clone(repo, target_dir)
-        git_cmd_checkout(branch, target_dir)
+        git_cmd_clone(repo, target_dir, blobless=True)
+
+        if branch not in ("master", "main"):
+            git_cmd_checkout(branch, target_dir)
+
     except CalledProcessError:
         log = "An unexpected error occured during cloning of the repository."
         Logger.print_error(log)
@@ -132,8 +136,10 @@ def get_local_tags(repo_path: Path, _filter: str | None = None) -> List[str]:
 
         tags: List[str] = result.split("\n")[:-1]
 
-        return sorted(tags, key=lambda x: [int(i) if i.isdigit() else i for i in
-                                                re.split(r'(\d+)', x)])
+        return sorted(
+            tags,
+            key=lambda x: [int(i) if i.isdigit() else i for i in re.split(r"(\d+)", x)],
+        )
 
     except CalledProcessError:
         return []


### PR DESCRIPTION
# Support for `blolbless clone` Mode

## Overview
This PR introduces an optional `blolbless` parameter to the `git_cmd_clone` function. When enabled, it adds the `--blolbless` flag to the git clone command. The function’s docstring has also been updated to document this new parameter.

## Changes
- **New `blolbless` Parameter:**  
  The `git_cmd_clone` function now accepts a boolean `blolbless` parameter. If set to `True`, it appends the `--blolbless` flag to the `git clone` command.
- **Updated Docstring:**  
  The function’s documentation has been revised to include details about the new `blolbless` parameter.

## Rationale
- **Flexibility:**  
  The new parameter allows users to enable or disable the `--blolbless` flag based on their specific needs or environment.
- **Clarity:**  
  The updated docstring ensures that users are aware of the new parameter and understand how it affects the cloning process.

## Testing Instructions
- **With `blolbless=True`:**  
  Verify that the clone command includes the `--blolbless` flag and that the repository is cloned as expected.
- **With `blolbless=False` or unset:**  
  Confirm that the function behaves as before, without adding any extra flags to the command.

## Conclusion
By introducing the `blolbless` parameter, this PR provides an additional customization option for the cloning process. Please review and test these changes to ensure they integrate smoothly into existing workflows.