### PR TITLE
Enable fluidd ipv6 support

### DIFF
--- a/resources/fluidd
+++ b/resources/fluidd
@@ -2,6 +2,7 @@
 
 server {
     listen 80;
+    listen [::]:80;
 
     access_log /var/log/nginx/fluidd-access.log;
     error_log /var/log/nginx/fluidd-error.log;


### PR DESCRIPTION
I found that I can't access the newly installed fluidd at the v6 address of my raspberry, after searching a bit I found this [pull request](https://github.com/fluidd-core/FluiddPI/pull/9) in the fluidd repository, after looking in the [kiauh resources](https://github.com/dw-0/kiauh/blob/9e0a8a008106f85f443215ae5982da6236f08806/resources/fluidd#L4) I didn't see the added line, I tested it locally by changing the same file that is in this pr and v6 started working for me