### PR TITLE
fix: Add pkg-config to klipper packages

### DIFF
--- a/kiauh/components/klipper/klipper_setup.py
+++ b/kiauh/components/klipper/klipper_setup.py
@@ -176,6 +176,9 @@ def install_klipper_packages() -> None:
     script = KLIPPER_INSTALL_SCRIPT
     packages = parse_packages_from_file(script)
 
+    # Add pkg-config for rp2040 build
+    packages.append("pkg-config")
+
     # Add dbus requirement for DietPi distro
     if Path("/boot/dietpi/.version").exists():
         packages.append("dbus")

--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -304,6 +304,8 @@ function install_klipper_packages() {
   packages=$(grep "PKGLIST=" "${install_script}" | cut -d'"' -f2 | sed 's/\${PKGLIST}//g' | tr -d '\n')
   ### add dfu-util for octopi-images
   packages+=" dfu-util"
+  ### add pkg-config for rp2040 build
+  packages+=" pkg-config"
   ### add dbus requirement for DietPi distro
   [[ -e "/boot/dietpi/.version" ]] && packages+=" dbus"
 


### PR DESCRIPTION
pkg-config is required for loading libusb header files to build rp2040 firmware

Signed-off-by: Andrey Kozhevnikov <coderusinbox@gmail.com>