### PR TITLE
fix: exception raised on pip warning

### DIFF
--- a/kiauh/utils/sys_utils.py
+++ b/kiauh/utils/sys_utils.py
@@ -193,7 +193,7 @@ def install_python_requirements(target: Path, requirements: Path) -> None:
         ]
         result = run(command, stderr=PIPE, text=True)
 
-        if result.returncode != 0 or result.stderr:
+        if result.returncode != 0:
             Logger.print_error(f"{result.stderr}", False)
             raise VenvCreationFailedException("Installing Python requirements failed!")
 
@@ -222,7 +222,7 @@ def install_python_packages(target: Path, packages: List[str]) -> None:
             command.append(pkg)
         result = run(command, stderr=PIPE, text=True)
 
-        if result.returncode != 0 or result.stderr:
+        if result.returncode != 0:
             Logger.print_error(f"{result.stderr}", False)
             raise VenvCreationFailedException("Installing Python requirements failed!")
 


### PR DESCRIPTION
pip seems to write to stderr on warnings, caused by retries. even if the process exits with 0.