### PR TITLE
fix: add moonraker-hmi and moonraker-telegram-bot to the blacklist

### DIFF
--- a/kiauh/core/instance_manager/base_instance.py
+++ b/kiauh/core/instance_manager/base_instance.py
@@ -16,8 +16,9 @@ from typing import List
 
 from utils.fs_utils import get_data_dir
 
-SUFFIX_BLACKLIST: List[str] = ["None", "mcu", "obico", "bambu", "companion"]
-
+# suffixes that are not allowed to be used for instances
+# because they would cause conflicts with other components or are reserved
+SUFFIX_BLACKLIST: List[str] = ["None", "mcu", "obico", "bambu", "companion", "hmi"]
 
 @dataclass(repr=True)
 class BaseInstance:

--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -27,7 +27,7 @@ function moonraker_systemd() {
   ###
   # any moonraker client that uses "moonraker" in its own name must be blacklisted using
   # this variable, otherwise they will be falsely recognized as moonraker instances
-  blacklist="obico"
+  blacklist="obico|hmi|telegram-bot"
 
   ignore="${SYSTEMD}/moonraker-(${blacklist}).service"
   match="${SYSTEMD}/moonraker(-[0-9a-zA-Z]+)?.service"


### PR DESCRIPTION
Hello, I developer of moonraker-hmi service, that allows you to reuse old, unsupported by klipper, LCDs.
So, my service name detected as additional moonraker instance. It will be nice to exclude it from the list.

Also, moonraker-telegram-bot has same issue. I have added both to blacklist in this commit.