### PR TITLE
feat(extension): Add DroidKlipp extension

### DIFF
--- a/kiauh/extensions/droidklipp/__init__.py
+++ b/kiauh/extensions/droidklipp/__init__.py
@@ -1,0 +1,23 @@
+# ======================================================================= #
+#  Copyright (C) 2026 Cody Dixon                                         #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from pathlib import Path
+
+# repo
+DROIDKLIPP_REPO = "https://github.com/CodeMasterCody3D/DroidKlipp"
+DROIDKLIPP_APK_URL = "https://github.com/CodeMasterCody3D/DroidKlipp-Android-APK/releases/latest/download/DroidKlipp.apk"
+
+# directories
+DROIDKLIPP_DIR = Path.home().joinpath("DroidKlipp")
+
+# files
+DROIDKLIPP_INSTALL_SCRIPT = DROIDKLIPP_DIR.joinpath("install_droidklipp.sh")
+DROIDKLIPP_UNINSTALL_SCRIPT = DROIDKLIPP_DIR.joinpath("uninstall_droidklipp.sh")
+
+# packages
+DROIDKLIPP_REQUIRED_PACKAGES = {"adb", "tmux", "x11-utils"}

--- a/kiauh/extensions/droidklipp/__init__.py
+++ b/kiauh/extensions/droidklipp/__init__.py
@@ -18,6 +18,12 @@ DROIDKLIPP_DIR = Path.home().joinpath("DroidKlipp")
 # files
 DROIDKLIPP_INSTALL_SCRIPT = DROIDKLIPP_DIR.joinpath("install_droidklipp.sh")
 DROIDKLIPP_UNINSTALL_SCRIPT = DROIDKLIPP_DIR.joinpath("uninstall_droidklipp.sh")
+# the monitor is shipped as a tracked file in the repo and deployed into $HOME
+DROIDKLIPP_MONITOR_FILE = DROIDKLIPP_DIR.joinpath("droidklipp_monitor.py")
+DROIDKLIPP_DEPLOYED_MONITOR = Path.home().joinpath("droidklipp_monitor.py")
+
+# service
+DROIDKLIPP_SERVICE_NAME = "adb_monitor"
 
 # packages
 DROIDKLIPP_REQUIRED_PACKAGES = {"adb", "tmux", "x11-utils"}

--- a/kiauh/extensions/droidklipp/__init__.py
+++ b/kiauh/extensions/droidklipp/__init__.py
@@ -18,7 +18,6 @@ DROIDKLIPP_DIR = Path.home().joinpath("DroidKlipp")
 # files
 DROIDKLIPP_INSTALL_SCRIPT = DROIDKLIPP_DIR.joinpath("install_droidklipp.sh")
 DROIDKLIPP_UNINSTALL_SCRIPT = DROIDKLIPP_DIR.joinpath("uninstall_droidklipp.sh")
-# the monitor is shipped as a tracked file in the repo and deployed into $HOME
 DROIDKLIPP_MONITOR_FILE = DROIDKLIPP_DIR.joinpath("droidklipp_monitor.py")
 DROIDKLIPP_DEPLOYED_MONITOR = Path.home().joinpath("droidklipp_monitor.py")
 

--- a/kiauh/extensions/droidklipp/droidklipp_extension.py
+++ b/kiauh/extensions/droidklipp/droidklipp_extension.py
@@ -1,0 +1,130 @@
+# ======================================================================= #
+#  Copyright (C) 2026 Cody Dixon                                         #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from subprocess import CalledProcessError, run
+
+from components.klipperscreen import KLIPPERSCREEN_DIR, KLIPPERSCREEN_ENV_DIR
+from core.logger import DialogType, Logger
+from extensions.base_extension import BaseExtension
+from extensions.droidklipp import (
+    DROIDKLIPP_APK_URL,
+    DROIDKLIPP_DIR,
+    DROIDKLIPP_INSTALL_SCRIPT,
+    DROIDKLIPP_REPO,
+    DROIDKLIPP_REQUIRED_PACKAGES,
+    DROIDKLIPP_UNINSTALL_SCRIPT,
+)
+from utils.common import check_install_dependencies
+from utils.fs_utils import check_file_exist, run_remove_routines
+from utils.git_utils import git_clone_wrapper, git_pull_wrapper
+from utils.input_utils import get_confirm
+
+
+# noinspection PyMethodMayBeStatic
+class DroidKlippExtension(BaseExtension):
+    def install_extension(self, **kwargs) -> None:
+        Logger.print_status("Installing DroidKlipp ...")
+
+        if not self._klipperscreen_exists():
+            Logger.print_dialog(
+                DialogType.WARNING,
+                [
+                    "No KIAUH v6 KlipperScreen installation found!",
+                    "DroidKlipp expects KlipperScreen at:",
+                    f"● {KLIPPERSCREEN_DIR.joinpath('screen.py')}",
+                    f"● {KLIPPERSCREEN_ENV_DIR.joinpath('bin/python')}",
+                    "Install KlipperScreen first, then run this installer again.",
+                ],
+            )
+            return
+
+        Logger.print_dialog(
+            DialogType.INFO,
+            [
+                "DroidKlipp requires the Android APK to be installed on your Android device:",
+                DROIDKLIPP_APK_URL,
+                "\n\n",
+                "The installer will configure ADB forwarding, udev rules, the DroidKlipp monitor, and WiFi fallback.",
+            ],
+        )
+
+        if not get_confirm(
+            "Continue DroidKlipp installation?",
+            default_choice=True,
+            allow_go_back=True,
+        ):
+            Logger.print_info("Exiting DroidKlipp installation ...")
+            return
+
+        try:
+            check_install_dependencies(DROIDKLIPP_REQUIRED_PACKAGES)
+            git_clone_wrapper(DROIDKLIPP_REPO, DROIDKLIPP_DIR)
+            run(["chmod", "+x", DROIDKLIPP_INSTALL_SCRIPT], check=True)
+            run([DROIDKLIPP_INSTALL_SCRIPT], check=True)
+            Logger.print_dialog(
+                DialogType.SUCCESS,
+                ["DroidKlipp successfully installed!"],
+                center_content=True,
+            )
+        except CalledProcessError as e:
+            Logger.print_error(f"Error during DroidKlipp installation:\n{e}")
+        except Exception as e:
+            Logger.print_error(f"Error during DroidKlipp installation:\n{e}")
+
+    def update_extension(self, **kwargs) -> None:
+        Logger.print_status("Updating DroidKlipp ...")
+
+        if not check_file_exist(DROIDKLIPP_DIR):
+            Logger.print_info("Extension does not seem to be installed! Skipping ...")
+            return
+
+        try:
+            git_pull_wrapper(DROIDKLIPP_DIR)
+            Logger.print_dialog(
+                DialogType.SUCCESS,
+                ["DroidKlipp successfully updated!"],
+                center_content=True,
+            )
+        except Exception as e:
+            Logger.print_error(f"Error during DroidKlipp update:\n{e}")
+
+    def remove_extension(self, **kwargs) -> None:
+        Logger.print_status("Removing DroidKlipp ...")
+
+        if not check_file_exist(DROIDKLIPP_DIR):
+            Logger.print_info("Extension does not seem to be installed! Skipping ...")
+            return
+
+        if not get_confirm(
+            "Do you really want to uninstall DroidKlipp?",
+            default_choice=True,
+            allow_go_back=True,
+        ):
+            Logger.print_info("Exiting DroidKlipp uninstallation ...")
+            return
+
+        try:
+            if check_file_exist(DROIDKLIPP_UNINSTALL_SCRIPT):
+                run(["chmod", "+x", DROIDKLIPP_UNINSTALL_SCRIPT], check=True)
+                run([DROIDKLIPP_UNINSTALL_SCRIPT], check=True)
+            run_remove_routines(DROIDKLIPP_DIR)
+            Logger.print_dialog(
+                DialogType.SUCCESS,
+                ["DroidKlipp successfully removed!"],
+                center_content=True,
+            )
+        except CalledProcessError as e:
+            Logger.print_error(f"Error during DroidKlipp removal:\n{e}")
+        except Exception as e:
+            Logger.print_error(f"Error during DroidKlipp removal:\n{e}")
+
+    def _klipperscreen_exists(self) -> bool:
+        return bool(
+            check_file_exist(KLIPPERSCREEN_DIR.joinpath("screen.py"))
+            and check_file_exist(KLIPPERSCREEN_ENV_DIR.joinpath("bin/python"))
+        )

--- a/kiauh/extensions/droidklipp/droidklipp_extension.py
+++ b/kiauh/extensions/droidklipp/droidklipp_extension.py
@@ -88,15 +88,10 @@ class DroidKlippExtension(BaseExtension):
             return
 
         try:
-            # the adb_monitor service runs the deployed monitor as a long-running
-            # daemon, so it must be stopped before and (re)started after the pull,
-            # otherwise the running process keeps executing the old in-memory code.
             cmd_sysctl_service(DROIDKLIPP_SERVICE_NAME, "stop")
 
             git_pull_wrapper(DROIDKLIPP_DIR)
 
-            # droidklipp_monitor.py is a tracked file in the repo but the service
-            # executes the copy deployed into $HOME, so re-deploy it after pulling.
             if check_file_exist(DROIDKLIPP_MONITOR_FILE):
                 run(
                     [
@@ -118,7 +113,6 @@ class DroidKlippExtension(BaseExtension):
             )
         except CalledProcessError as e:
             Logger.print_error(f"Error during DroidKlipp update:\n{e}")
-            # best-effort restart so we never leave the service stopped on failure
             cmd_sysctl_service(DROIDKLIPP_SERVICE_NAME, "start")
         except Exception as e:
             Logger.print_error(f"Error during DroidKlipp update:\n{e}")

--- a/kiauh/extensions/droidklipp/droidklipp_extension.py
+++ b/kiauh/extensions/droidklipp/droidklipp_extension.py
@@ -13,16 +13,20 @@ from core.logger import DialogType, Logger
 from extensions.base_extension import BaseExtension
 from extensions.droidklipp import (
     DROIDKLIPP_APK_URL,
+    DROIDKLIPP_DEPLOYED_MONITOR,
     DROIDKLIPP_DIR,
     DROIDKLIPP_INSTALL_SCRIPT,
+    DROIDKLIPP_MONITOR_FILE,
     DROIDKLIPP_REPO,
     DROIDKLIPP_REQUIRED_PACKAGES,
+    DROIDKLIPP_SERVICE_NAME,
     DROIDKLIPP_UNINSTALL_SCRIPT,
 )
 from utils.common import check_install_dependencies
 from utils.fs_utils import check_file_exist, run_remove_routines
 from utils.git_utils import git_clone_wrapper, git_pull_wrapper
 from utils.input_utils import get_confirm
+from utils.sys_utils import cmd_sysctl_service
 
 
 # noinspection PyMethodMayBeStatic
@@ -84,14 +88,41 @@ class DroidKlippExtension(BaseExtension):
             return
 
         try:
+            # the adb_monitor service runs the deployed monitor as a long-running
+            # daemon, so it must be stopped before and (re)started after the pull,
+            # otherwise the running process keeps executing the old in-memory code.
+            cmd_sysctl_service(DROIDKLIPP_SERVICE_NAME, "stop")
+
             git_pull_wrapper(DROIDKLIPP_DIR)
+
+            # droidklipp_monitor.py is a tracked file in the repo but the service
+            # executes the copy deployed into $HOME, so re-deploy it after pulling.
+            if check_file_exist(DROIDKLIPP_MONITOR_FILE):
+                run(
+                    [
+                        "install",
+                        "-m",
+                        "755",
+                        str(DROIDKLIPP_MONITOR_FILE),
+                        str(DROIDKLIPP_DEPLOYED_MONITOR),
+                    ],
+                    check=True,
+                )
+
+            cmd_sysctl_service(DROIDKLIPP_SERVICE_NAME, "start")
+
             Logger.print_dialog(
                 DialogType.SUCCESS,
                 ["DroidKlipp successfully updated!"],
                 center_content=True,
             )
+        except CalledProcessError as e:
+            Logger.print_error(f"Error during DroidKlipp update:\n{e}")
+            # best-effort restart so we never leave the service stopped on failure
+            cmd_sysctl_service(DROIDKLIPP_SERVICE_NAME, "start")
         except Exception as e:
             Logger.print_error(f"Error during DroidKlipp update:\n{e}")
+            cmd_sysctl_service(DROIDKLIPP_SERVICE_NAME, "start")
 
     def remove_extension(self, **kwargs) -> None:
         Logger.print_status("Removing DroidKlipp ...")

--- a/kiauh/extensions/droidklipp/metadata.json
+++ b/kiauh/extensions/droidklipp/metadata.json
@@ -1,0 +1,17 @@
+{
+  "metadata": {
+    "index": 15,
+    "module": "droidklipp_extension",
+    "maintained_by": "CodeMasterCody3D",
+    "display_name": "DroidKlipp",
+    "description": [
+      "Use an Android device as a KlipperScreen display via ADB and DroidKlipp APK / XServer XSDL integration",
+      "- Automatic USB ADB forwarding",
+      "- Optional WiFi fallback",
+      "- Starts and monitors KlipperScreen on the Android X server"
+    ],
+    "website": "https://github.com/CodeMasterCody3D/DroidKlipp-Android-APK/releases/latest/download/DroidKlipp.apk",
+    "repo": "https://github.com/CodeMasterCody3D/DroidKlipp",
+    "updates": true
+  }
+}

--- a/kiauh/extensions/droidklipp/metadata.json
+++ b/kiauh/extensions/droidklipp/metadata.json
@@ -10,7 +10,7 @@
       "- Optional WiFi fallback",
       "- Starts and monitors KlipperScreen on the Android X server"
     ],
-    "website": "https://github.com/CodeMasterCody3D/DroidKlipp-Android-APK/releases/latest/download/DroidKlipp.apk",
+    "website": "https://github.com/CodeMasterCody3D/DroidKlipp-Android-APK/releases",
     "repo": "https://github.com/CodeMasterCody3D/DroidKlipp",
     "updates": true
   }


### PR DESCRIPTION
## Summary
- Adds DroidKlipp to the KIAUH Extensions menu as an auto-discovered extension
- Installs prerequisites for DroidKlipp: adb, tmux, and x11-utils
- Uses the updated DroidKlipp installer script: install_droidklipp.sh
- Adds update and remove actions for the extension
- Shows the DroidKlipp Android APK link before installation

## Details
DroidKlipp allows using an Android device as a KlipperScreen display via ADB and the DroidKlipp APK / XServer XSDL integration. The extension checks for the standard KIAUH v6 KlipperScreen paths before running the installer:

- ~/KlipperScreen/screen.py
- ~/.KlipperScreen-env/bin/python

## Test Plan
- python3 -m compileall -q kiauh/extensions/droidklipp
- Verified KIAUH extension discovery imports DroidKlipp at index 15
- uvx ruff format kiauh/extensions/droidklipp
- uvx ruff check kiauh/extensions/droidklipp
- uvx --from mypy==1.14.1 mypy kiauh/extensions/droidklipp --ignore-missing-imports --python-version 3.8
- uvx --with pytest pytest -q: 905 passed
