### PR TITLE
feat(extensions): add Enable HTTPS extension (Let's Encrypt / certbot DNS-01)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# ======================================================================= #
+#  KIAUH code owners - review-routing ownership zones.                     #
+#                                                                          #
+#  Default owner is the project maintainer. Bundled extensions are owned   #
+#  by their respective authors, as declared in each extension's            #
+#  metadata.json ("maintained_by" field).                                  #
+#  https://docs.github.com/articles/about-code-owners                      #
+# ======================================================================= #
+
+# Default owner for the whole repository.
+*                                                    @dw-0
+
+# Externally maintained extensions (owner = metadata.json "maintained_by").
+/kiauh/extensions/https/                             @lexfrei
+/kiauh/extensions/klipper_adaptive_meshing_purging/  @theogayar
+/kiauh/extensions/klipper_backup/                    @Staubgeborener
+/kiauh/extensions/mobileraker/                       @Clon1998
+/kiauh/extensions/obico/                             @obico
+/kiauh/extensions/octoapp/                           @crysxd
+/kiauh/extensions/octoeverywhere/                    @QuinnDamerell
+/kiauh/extensions/pretty_gcode/                      @Kragrathea
+/kiauh/extensions/telegram_bot/                      @nlef
+/kiauh/extensions/tmc_autotune/                      @theogayar

--- a/kiauh/components/webui_client/client_utils.py
+++ b/kiauh/components/webui_client/client_utils.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import json
-import re
 import shutil
 from json import JSONDecodeError
 from pathlib import Path
@@ -47,6 +46,7 @@ from utils.git_utils import (
 )
 from utils.input_utils import get_number_input
 from utils.instance_utils import get_instances
+from utils.nginx_utils import config_enables_https, listen_ports
 
 
 def get_client_status(
@@ -383,17 +383,21 @@ def get_nginx_listen_port(config: Path) -> int | None:
     :return: The listen port as int or None if not found/parsable
     """
 
-    # noinspection HttpUrlsUsage
-    pattern = r"default_server|http://|https://|[;\[\]]"
     port = ""
     with open(config, "r") as cfg:
         for line in cfg.readlines():
-            line = re.sub(pattern, "", line.strip())
-            if line.startswith("listen"):
-                if ":" not in line:
-                    port = line.split()[-1]
-                else:
-                    port = line.split(":")[-1]
+            stripped = line.strip()
+            if not stripped.startswith("listen"):
+                continue
+            # take the address[:port] token right after the "listen" keyword and
+            # keep the part after the last ":" so both "listen 443 ssl http2;" and
+            # "listen [::]:80;" yield the numeric port instead of a trailing flag
+            fields = stripped[len("listen") :].strip().rstrip(";").split()
+            if not fields:
+                continue
+            token = fields[0].split(":")[-1].strip("[]")
+            if token.isdigit():
+                port = token
         try:
             return int(port)
         except ValueError:
@@ -403,22 +407,36 @@ def get_nginx_listen_port(config: Path) -> int | None:
             return None
 
 
+def is_https_nginx_config(config: Path) -> bool:
+    """
+    Check whether an NGINX site already contains a TLS (HTTPS) server block.
+    :param config: The NGINX config file to inspect
+    :return: True if an active 'listen 443 ssl' directive is present, else False
+    """
+    try:
+        return config_enables_https(config.read_text())
+    except OSError:
+        return False
+
+
 def read_ports_from_nginx_configs() -> List[int]:
     """
     Helper function to iterate over all NGINX configs
-    and read all ports defined for listen
-    :return: A sorted list of listen ports
+    and read EVERY port defined for listen (not just the last one per file, so
+    a dual-listen HTTPS site reports both its redirect port and 443).
+    :return: A sorted list of unique listen ports
     """
     if not NGINX_SITES_ENABLED.exists():
         return []
 
-    port_list: List[int] = []
+    ports: set[int] = set()
     for config in get_nginx_config_list():
-        port = get_nginx_listen_port(config)
-        if port is not None:
-            port_list.append(port)
+        try:
+            ports.update(listen_ports(config.read_text()))
+        except OSError:
+            continue
 
-    return sorted(port_list, key=lambda x: int(x))
+    return sorted(ports)
 
 
 def get_client_port_selection(

--- a/kiauh/components/webui_client/menus/client_install_menu.py
+++ b/kiauh/components/webui_client/menus/client_install_menu.py
@@ -15,6 +15,7 @@ from components.webui_client.base_data import BaseWebClient
 from components.webui_client.client_utils import (
     get_client_port_selection,
     get_nginx_listen_port,
+    is_https_nginx_config,
     set_listen_port,
 )
 from components.webui_client.services.web_client_setup_service import (
@@ -67,11 +68,41 @@ class ClientInstallMenu(BaseMenu):
         print(menu, end="")
 
     def reinstall_client(self, **kwargs) -> None:
+        # reinstalling regenerates the plain-HTTP nginx site from the template,
+        # which would silently strip the TLS block and orphan the certificate;
+        # refuse while HTTPS is on and point at the HTTPS extension instead
+        if is_https_nginx_config(self.client.nginx_config):
+            message = Message(
+                title="HTTPS is enabled",
+                text=[
+                    f"{self.client.display_name} is currently served over HTTPS.",
+                    "Disable HTTPS (Extensions menu) before reinstalling.",
+                ],
+                color=Color.YELLOW,
+            )
+            self.message_service.set_message(message)
+            return
+
         WebClientSetupService(self.client.name).install(
             reinstall=True, interactive=True
         )
 
     def change_listen_port(self, **kwargs) -> None:
+        # an HTTPS site has a dedicated 443 TLS block plus an :80 redirect;
+        # rewriting the port here would strip the TLS config and orphan the
+        # certificate, so refuse and point at the HTTPS extension instead
+        if is_https_nginx_config(self.client.nginx_config):
+            message = Message(
+                title="HTTPS is enabled",
+                text=[
+                    f"{self.client.display_name} is currently served over HTTPS.",
+                    "Disable HTTPS (Extensions menu) before changing the listen port.",
+                ],
+                color=Color.YELLOW,
+            )
+            self.message_service.set_message(message)
+            return
+
         curr_port = self._get_current_port()
         new_port = get_client_port_selection(
             self.client,

--- a/kiauh/components/webui_client/menus/tests/test_client_install_menu.py
+++ b/kiauh/components/webui_client/menus/tests/test_client_install_menu.py
@@ -103,3 +103,89 @@ class TestClientInstallMenu:
         assert captured["nginx"] == ["stop", "start"]
         assert captured["set_port"] == (80, 9090)
         assert menu.client_settings.port == 9090
+
+
+class _CapturingMessageService:
+    def __init__(self) -> None:
+        self.messages: List[Any] = []
+
+    def set_message(self, message: Any) -> None:
+        self.messages.append(message)
+
+
+class TestHttpsGuards:
+    """Both menu actions rewrite the nginx site from the plain-HTTP template.
+
+    Doing that on a TLS site strips the 443 block and orphans the certificate,
+    so both must refuse while HTTPS is enabled.
+    """
+
+    def _menu_for(
+        self, monkeypatch, tmp_path: Path, config_text: str
+    ) -> ClientInstallMenu:
+        site = tmp_path.joinpath("mainsail")
+        site.write_text(config_text)
+        menu = _build_menu(monkeypatch)
+        menu.client.nginx_config = site
+        menu.message_service = _CapturingMessageService()
+        return menu
+
+    def test_reinstall_refused_on_https_site(self, monkeypatch, tmp_path) -> None:
+        menu = self._menu_for(
+            monkeypatch,
+            tmp_path,
+            "server {\n    listen 443 ssl http2;\n    server_name x _;\n}\n",
+        )
+        installed: List[Any] = []
+        monkeypatch.setattr(
+            cim_module, "WebClientSetupService", lambda name: installed.append(name)
+        )
+
+        menu.reinstall_client()
+
+        assert not installed
+        assert menu.message_service.messages
+
+    def test_change_listen_port_refused_on_https_site(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        menu = self._menu_for(
+            monkeypatch,
+            tmp_path,
+            "server {\n    listen 443 ssl http2;\n    server_name x _;\n}\n",
+        )
+        touched: List[Any] = []
+        monkeypatch.setattr(
+            cim_module, "set_listen_port", lambda *a: touched.append("set_port")
+        )
+        monkeypatch.setattr(
+            cim_module, "cmd_sysctl_service", lambda *a: touched.append("nginx")
+        )
+
+        menu.change_listen_port()
+
+        # the port is never rewritten and nginx is never bounced
+        assert not touched
+        assert menu.message_service.messages
+
+    def test_reinstall_proceeds_on_plain_http_site(self, monkeypatch, tmp_path) -> None:
+        menu = self._menu_for(
+            monkeypatch,
+            tmp_path,
+            "server {\n    listen 80;\n    server_name _;\n}\n",
+        )
+        calls: List[Any] = []
+
+        class _FakeService:
+            def install(self, **kwargs) -> bool:
+                calls.append(kwargs)
+                return True
+
+        monkeypatch.setattr(
+            cim_module, "WebClientSetupService", lambda name: _FakeService()
+        )
+
+        menu.reinstall_client()
+
+        assert calls
+        assert calls[0]["reinstall"] is True

--- a/kiauh/components/webui_client/tests/__init__.py
+++ b/kiauh/components/webui_client/tests/__init__.py
@@ -1,0 +1,8 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #

--- a/kiauh/components/webui_client/tests/test_client_utils.py
+++ b/kiauh/components/webui_client/tests/test_client_utils.py
@@ -20,6 +20,7 @@ from components.webui_client.client_utils import (
     get_next_free_port,
     get_nginx_listen_port,
     get_remote_client_version,
+    is_https_nginx_config,
     read_ports_from_nginx_configs,
     set_listen_port,
 )
@@ -141,6 +142,37 @@ class TestNginxPortParsing:
         cfg.write_text("server {\n}\n")
         assert get_nginx_listen_port(cfg) is None
 
+    @pytest.mark.parametrize(
+        ("listen_line", "expected"),
+        [
+            ("    listen 80 default_server;", 80),
+            ("    listen [::]:80;", 80),
+            # a TLS listen: the trailing flags must not be mistaken for the port
+            ("    listen 443 ssl http2;", 443),
+            ("    listen [::]:443 ssl http2;", 443),
+        ],
+    )
+    def test_parses_tls_and_ipv6_listen(
+        self, tmp_path: Path, listen_line: str, expected: int
+    ) -> None:
+        cfg = tmp_path / "site"
+        cfg.write_text(f"server {{\n{listen_line}\n    server_name _;\n}}\n")
+        assert get_nginx_listen_port(cfg) == expected
+
+    def test_returns_none_when_unparsable(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "site"
+        cfg.write_text("server {\n    listen ssl;\n}\n")
+        assert get_nginx_listen_port(cfg) is None
+
+    def test_https_dual_block_returns_443(self, tmp_path: Path) -> None:
+        # the HTTPS rewrite yields an :80 redirect block plus a 443 TLS block
+        cfg = tmp_path / "site"
+        cfg.write_text(
+            "server {\n    listen 80;\n    return 301 https://printer.example.com$request_uri;\n}\n"
+            "server {\n    listen 443 ssl http2;\n    server_name printer.example.com _;\n}\n"
+        )
+        assert get_nginx_listen_port(cfg) == 443
+
     def test_reads_all_configs_in_enabled_dir(
         self, monkeypatch, tmp_path: Path
     ) -> None:
@@ -153,9 +185,45 @@ class TestNginxPortParsing:
         ports = read_ports_from_nginx_configs()
         assert ports == [1000, 2000]
 
+    def test_reads_every_listen_port_not_just_the_last(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        # an HTTPS site has both the :80 redirect block and the :443 TLS block;
+        # availability checks must see BOTH, not just the last listen in the file
+        sites = tmp_path / "sites-enabled"
+        sites.mkdir()
+        (sites / "mainsail").write_text(
+            "server {\n    listen 80;\n}\nserver {\n    listen 443 ssl http2;\n}\n"
+        )
+        (sites / "fluidd").write_text("server {\n    listen 8080;\n}\n")
+        monkeypatch.setattr(client_utils, "NGINX_SITES_ENABLED", sites)
+
+        assert read_ports_from_nginx_configs() == [80, 443, 8080]
+
     def test_returns_empty_when_enabled_dir_missing(self, monkeypatch) -> None:
         monkeypatch.setattr(client_utils, "NGINX_SITES_ENABLED", Path("/missing"))
         assert read_ports_from_nginx_configs() == []
+
+
+class TestIsHttpsNginxConfig:
+    def test_true_for_tls_block(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "site"
+        cfg.write_text("server {\n    listen 443 ssl http2;\n}\n")
+        assert is_https_nginx_config(cfg) is True
+
+    def test_false_for_plain_http(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "site"
+        cfg.write_text("server {\n    listen 80;\n}\n")
+        assert is_https_nginx_config(cfg) is False
+
+    def test_false_when_missing(self, tmp_path: Path) -> None:
+        assert is_https_nginx_config(tmp_path / "nope") is False
+
+    def test_ignores_commented_directive(self, tmp_path: Path) -> None:
+        # a commented-out example must not be read as an enabled TLS block
+        cfg = tmp_path / "site"
+        cfg.write_text("server {\n    listen 80;\n    # listen 443 ssl;\n}\n")
+        assert is_https_nginx_config(cfg) is False
 
 
 class TestSetListenPort:

--- a/kiauh/extensions/https/__init__.py
+++ b/kiauh/extensions/https/__init__.py
@@ -1,0 +1,27 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from pathlib import Path
+
+MODULE_PATH: Path = Path(__file__).resolve().parent
+
+# Root-owned directory holding the DNS provider credentials (chmod 700).
+SECRETS_DIR: Path = Path("/root/.secrets")
+# Where certbot stores issued certificates, one subdirectory per FQDN.
+LE_LIVE_DIR: Path = Path("/etc/letsencrypt/live")
+# certbot runs every executable here after a certificate is actually renewed.
+RENEWAL_HOOK_DIR: Path = Path("/etc/letsencrypt/renewal-hooks/deploy")
+
+# A conservative hostname matcher: labels of 1-63 chars, at least two of them,
+# no leading/trailing hyphen, total length up to 253.
+FQDN_REGEX: str = (
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+    r"(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+# A deliberately loose email check; certbot does the authoritative validation.
+EMAIL_REGEX: str = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"

--- a/kiauh/extensions/https/certbot.py
+++ b/kiauh/extensions/https/certbot.py
@@ -1,0 +1,210 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+"""
+Thin, side-effecting wrappers around certbot, apt and the credentials/renewal
+files. Each function shells out via the same patterns the rest of KIAUH uses
+(sudo + subprocess.run) and is kept small so it can be mocked in tests. The
+DNS provider secret only ever flows into the credentials file through tee's
+stdin - never as a command argument, a log line, or KIAUH config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import DEVNULL, PIPE, run
+from typing import Dict, List, Optional, Tuple
+
+from core.logger import Logger
+from extensions.https import LE_LIVE_DIR, RENEWAL_HOOK_DIR, SECRETS_DIR
+from extensions.https.providers import (
+    DnsProvider,
+    build_certbot_command,
+    build_credentials_content,
+)
+from utils.sys_utils import check_package_install, install_system_packages
+
+RENEW_HOOK_NAME = "kiauh-reload-nginx.sh"
+RENEW_HOOK_CONTENT = "#!/bin/sh\nsystemctl reload nginx\n"
+# certbot writes its full (root-only) diagnostic log here; point users at it
+# rather than dumping certbot's stderr, which we never capture.
+LETSENCRYPT_LOG = "/var/log/letsencrypt/letsencrypt.log"
+
+
+def _sudo(args: List[str]) -> None:
+    """Run `sudo <args>` and raise CalledProcessError on failure."""
+    run(["sudo", *args], stderr=PIPE, check=True)
+
+
+def _sudo_write(target: Path, content: str) -> None:
+    """
+    Write `content` to a root-owned file via `sudo tee`. The content is passed
+    through stdin (never as an argument) and tee's stdout is discarded so a
+    secret can never be echoed back to the terminal.
+    """
+    run(
+        ["sudo", "tee", str(target)],
+        input=content.encode(),
+        stdout=DEVNULL,
+        stderr=PIPE,
+        check=True,
+    )
+
+
+def cert_paths(fqdn: str) -> Tuple[Path, Path]:
+    """Return the (fullchain.pem, privkey.pem) paths certbot uses for `fqdn`."""
+    live = LE_LIVE_DIR.joinpath(fqdn)
+    return live.joinpath("fullchain.pem"), live.joinpath("privkey.pem")
+
+
+def ensure_certbot(provider: DnsProvider) -> None:
+    """Install certbot and the provider's DNS plugin if they are not present."""
+    missing = check_package_install({"certbot", provider.plugin_package})
+    if not missing:
+        return
+    Logger.print_status(f"Installing certbot packages: {', '.join(missing)} ...")
+    install_system_packages(missing)
+
+
+def credentials_file(fqdn: str) -> Path:
+    """Return the per-certificate credentials file path for ``fqdn``."""
+    return SECRETS_DIR.joinpath(f"{fqdn}.ini")
+
+
+def write_credentials(provider: DnsProvider, values: Dict[str, str], fqdn: str) -> Path:
+    """
+    Write the provider credentials to a root-owned 0600 file under SECRETS_DIR
+    and return its path. The directory is created and locked to 0700 first.
+
+    The file is named per certificate (``<fqdn>.ini``), not per provider, so
+    issuing or re-issuing one certificate never overwrites - and a failed run
+    never deletes - the credentials another certificate's renewal depends on.
+
+    :raises ValueError: if the provider has no credentials file (env/IAM auth)
+    """
+    if not provider.credentials_filename:
+        raise ValueError(f"Provider '{provider.key}' does not use a credentials file.")
+
+    target: Path = credentials_file(fqdn)
+    content = build_credentials_content(provider, values)
+
+    Logger.print_status(f"Writing DNS credentials to {target} ...")
+    _sudo(["mkdir", "-p", str(SECRETS_DIR)])
+    _sudo(["chmod", "700", str(SECRETS_DIR)])
+    _sudo_write(target, content)
+    _sudo(["chmod", "600", str(target)])
+    return target
+
+
+def remove_credentials(credentials_path: Path) -> None:
+    """
+    Remove a credentials file written by write_credentials. Idempotent
+    (``rm -f``); used to clean up the token after a failed, aborted issuance so
+    a secret-bearing file is not left behind for an operation that never
+    completed.
+    """
+    run(["sudo", "rm", "-f", str(credentials_path)], stderr=PIPE, check=True)
+
+
+def credentials_exist(fqdn: str) -> bool:
+    """
+    Return True if a credentials file for ``fqdn`` already exists. The check
+    goes through sudo because the file lives in a 0700 directory the non-root
+    caller cannot stat directly. Used to reuse the working credentials of a
+    retained certificate on re-enable rather than overwrite them unvalidated.
+    """
+    path = credentials_file(fqdn)
+    return run(["sudo", "test", "-f", str(path)], stderr=PIPE).returncode == 0
+
+
+def credentials_match_provider(fqdn: str, provider: DnsProvider) -> bool:
+    """
+    Return True if the saved credentials file for ``fqdn`` looks compatible with
+    ``provider`` - i.e. it contains the provider's first expected ini key. The
+    file is a DNS-plugin-specific INI, so reusing one provider's file with
+    another's plugin would fail; this guards against offering such a reuse.
+
+    Checked via ``sudo grep`` on the key NAME (``-q``, no output) so the secret
+    value is never read out of the root-owned file.
+    """
+    if not provider.credentials_fields:
+        return True
+    key = provider.credentials_fields[0].ini_key
+    path = credentials_file(fqdn)
+    return (
+        run(["sudo", "grep", "-q", "--", key, str(path)], stderr=PIPE).returncode == 0
+    )
+
+
+def backup_credentials(fqdn: str) -> Path:
+    """
+    Copy the existing credentials file for ``fqdn`` aside as a root-owned
+    ``.bak`` and return the backup path, so a failed replacement can restore the
+    credentials a retained certificate still renews with. The caller must ensure
+    the file exists first (see ``credentials_exist``).
+    """
+    path = credentials_file(fqdn)
+    backup = path.with_name(path.name + ".bak")
+    run(["sudo", "cp", "-p", str(path), str(backup)], stderr=PIPE, check=True)
+    return backup
+
+
+def restore_credentials(backup: Path, fqdn: str) -> None:
+    """Move a credentials backup back into place (root-owned)."""
+    run(
+        ["sudo", "mv", str(backup), str(credentials_file(fqdn))],
+        stderr=PIPE,
+        check=True,
+    )
+
+
+def discard_credentials_backup(backup: Path) -> None:
+    """Remove a credentials backup file. Idempotent (``rm -f``)."""
+    run(["sudo", "rm", "-f", str(backup)], stderr=PIPE, check=True)
+
+
+def run_certbot(
+    provider: DnsProvider,
+    fqdn: str,
+    email: str,
+    propagation_seconds: int,
+    credentials_path: Optional[Path],
+    force_renewal: bool = False,
+) -> None:
+    """
+    Run `certbot certonly` for a DNS-01 issuance. certbot's progress is shown
+    live (its output is not captured, so a secret cannot leak through it).
+
+    With ``force_renewal`` certbot performs a real DNS challenge rather than
+    keeping an unexpired certificate - used when replacing credentials so the
+    new token is validated instead of silently accepted.
+
+    :raises CalledProcessError: on failure - the caller MUST NOT touch nginx
+        unless this returns successfully
+    """
+    cred = str(credentials_path) if credentials_path is not None else None
+    cmd = build_certbot_command(
+        provider, fqdn, email, propagation_seconds, cred, force_renewal=force_renewal
+    )
+    Logger.print_status(
+        f"Requesting certificate for {fqdn} via {provider.display_name} DNS-01 ..."
+    )
+    run(cmd, check=True)
+
+
+def install_renew_hook() -> None:
+    """
+    Install a certbot deploy hook that reloads nginx after a successful
+    renewal. Idempotent (overwrites) and applies to every certificate; deploy
+    hooks run only when a certificate is actually renewed.
+    """
+    target = RENEWAL_HOOK_DIR.joinpath(RENEW_HOOK_NAME)
+    Logger.print_status("Installing nginx reload hook for certificate renewal ...")
+    _sudo(["mkdir", "-p", str(RENEWAL_HOOK_DIR)])
+    _sudo_write(target, RENEW_HOOK_CONTENT)
+    _sudo(["chmod", "0755", str(target)])

--- a/kiauh/extensions/https/https_extension.py
+++ b/kiauh/extensions/https/https_extension.py
@@ -1,0 +1,594 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import Dict, List, Optional
+
+from components.webui_client.base_data import BaseWebClient
+from components.webui_client.client_utils import (
+    get_existing_clients,
+    get_nginx_config_list,
+    get_nginx_listen_port,
+)
+from core.constants import NGINX_SITES_ENABLED
+from core.logger import DialogType, Logger
+from core.settings.kiauh_settings import KiauhSettings
+from extensions.base_extension import BaseExtension
+from extensions.https import EMAIL_REGEX, FQDN_REGEX
+from extensions.https.certbot import (
+    LETSENCRYPT_LOG,
+    backup_credentials,
+    cert_paths,
+    credentials_exist,
+    credentials_file,
+    credentials_match_provider,
+    discard_credentials_backup,
+    ensure_certbot,
+    install_renew_hook,
+    remove_credentials,
+    restore_credentials,
+    run_certbot,
+    write_credentials,
+)
+from extensions.https.nginx_https import (
+    AlreadyHttpsError,
+    build_http_config,
+    build_https_config,
+    extract_fqdn,
+    extract_redirect_port,
+)
+from extensions.https.nginx_ops import (
+    backup_site,
+    discard_backup,
+    nginx_config_test,
+    reload_nginx,
+    restore_site,
+    write_site,
+)
+from extensions.https.providers import PROVIDERS, DnsProvider
+from utils.input_utils import (
+    get_confirm,
+    get_secret_input,
+    get_selection_input,
+    get_string_input,
+)
+from utils.nginx_utils import config_enables_https, listen_ports
+from utils.sys_utils import get_distro_info
+
+# certbot is packaged for Debian/Ubuntu and their derivatives (apt). get_distro_info
+# returns the raw distro ID (it only remaps raspbian -> debian), so accept the
+# common Debian/Ubuntu-derived IDs explicitly. A fully robust check would consult
+# ID_LIKE from /etc/os-release, which get_distro_info does not expose today.
+SUPPORTED_DISTRO_IDS = {
+    "debian",
+    "ubuntu",
+    "raspbian",
+    "armbian",
+    "linuxmint",
+    "pop",
+    "neon",
+    "zorin",
+    "elementary",
+    "devuan",
+}
+HTTPS_PORT = 443
+
+
+# noinspection PyMethodMayBeStatic
+class HttpsExtension(BaseExtension):
+    def install_extension(self, **kwargs) -> None:
+        if not self._distro_supported():
+            return
+
+        client = self._select_client()
+        if client is None:
+            return
+
+        site: Path = client.nginx_config
+        current = self._read_site(site)
+        if current is None:
+            return
+
+        # The client dir can exist while its sites-enabled symlink was removed;
+        # rewriting the unloaded sites-available file would pass nginx -t yet
+        # leave HTTPS unserved. Require the site to be enabled first.
+        if not NGINX_SITES_ENABLED.joinpath(client.name).exists():
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    f"The nginx site for {client.display_name} is not enabled.",
+                    "Enable it (symlink in sites-enabled) before enabling HTTPS.",
+                ],
+            )
+            return
+
+        if config_enables_https(current):
+            Logger.print_dialog(
+                DialogType.INFO,
+                [f"HTTPS is already enabled for {client.display_name}."],
+            )
+            return
+
+        if self._port_443_in_use():
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    "Port 443 is already in use by another nginx site.",
+                    "Disable HTTPS there or remove the conflict first.",
+                ],
+            )
+            return
+
+        provider = self._select_provider()
+        # certbot canonicalizes the lineage to lowercase, so normalize here too:
+        # otherwise cert_paths() for "Printer.Example.com" points at a directory
+        # certbot never created and nginx -t fails after a successful issuance.
+        fqdn = get_string_input(
+            "Printer FQDN (e.g. printer.example.com)", regex=FQDN_REGEX
+        ).lower()
+
+        # Build the rewritten config now, before any package install or
+        # certificate issuance. A site we cannot rewrite (malformed, no server
+        # block) must fail here - never after a certificate has been issued.
+        # The redirect block keeps the port the site is currently served on, so
+        # enabling and later disabling HTTPS round-trips to the same port.
+        redirect_port = get_nginx_listen_port(site)
+        if redirect_port is None:
+            # Guessing a default here would silently move the site to a wrong
+            # port and break the round-trip on disable; abort instead.
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    f"Could not determine the listen port from {site}.",
+                    "The site was left unchanged.",
+                ],
+            )
+            return
+        new_config = self._build_https_config(current, fqdn, redirect_port)
+        if new_config is None:
+            return
+
+        email = get_string_input("Let's Encrypt contact email", regex=EMAIL_REGEX)
+        propagation = provider.default_propagation
+
+        # Prefer reusing the credentials of a certificate kept from a previous
+        # enable: re-issuing a still-valid cert is a no-op (--keep-until-expiring)
+        # that never validates a freshly typed token, so overwriting the working
+        # file could silently break renewal. Only offer reuse when the saved file
+        # actually matches the selected provider (its INI is plugin-specific);
+        # declining, or a provider change, falls through to writing new ones.
+        creds_existed = credentials_exist(fqdn)
+        reuse_credentials = bool(
+            creds_existed
+            and credentials_match_provider(fqdn, provider)
+            and get_confirm(
+                f"Saved credentials for {fqdn} found. Reuse them?",
+                default_choice=True,
+            )
+        )
+        values: Dict[str, str] = (
+            {} if reuse_credentials else self._prompt_credentials(provider)
+        )
+
+        self._print_summary(
+            client, provider, fqdn, reusing_credentials=reuse_credentials
+        )
+        if not get_confirm("Continue?", default_choice=True):
+            return
+
+        try:
+            ensure_certbot(provider)
+        except CalledProcessError:
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    "Could not install certbot or the DNS plugin.",
+                    "Check the network and apt, then try again.",
+                    "nginx was left unchanged.",
+                ],
+            )
+            return
+
+        # Replacing existing credentials: back the working file up first so a
+        # failed issuance can restore it. If the backup cannot be made, abort
+        # rather than overwrite an unrecoverable working file.
+        replacing = creds_existed and not reuse_credentials
+        creds_backup: Optional[Path] = None
+        if replacing:
+            try:
+                creds_backup = backup_credentials(fqdn)
+            except CalledProcessError:
+                Logger.print_dialog(
+                    DialogType.ERROR,
+                    [
+                        "Could not back up the existing DNS credentials.",
+                        "Aborting so the working credentials are not overwritten.",
+                        "nginx was left unchanged.",
+                    ],
+                )
+                return
+
+        # Write the token (unless reusing) and issue the certificate. Treated as
+        # one unit: until run_certbot succeeds no certificate references these
+        # credentials, so a failure here can safely undo the credentials change.
+        # Replacing credentials forces a real renewal so the new token is
+        # validated, not silently kept by --keep-until-expiring.
+        try:
+            creds_path = (
+                credentials_file(fqdn)
+                if reuse_credentials
+                else write_credentials(provider, values, fqdn)
+            )
+            run_certbot(
+                provider, fqdn, email, propagation, creds_path, force_renewal=replacing
+            )
+        except CalledProcessError:
+            self._undo_credentials(reuse_credentials, creds_existed, creds_backup, fqdn)
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    "Failed to obtain the certificate.",
+                    "Check the DNS provider token (scope and validity) and that "
+                    "sudo and apt are available.",
+                    f"Full details: {LETSENCRYPT_LOG} (root only).",
+                    "nginx was left unchanged.",
+                ],
+            )
+            return
+
+        # The certificate now exists and its renewal config references creds_path,
+        # so the credentials must stay from here on - drop the backup.
+        if creds_backup is not None:
+            try:
+                discard_credentials_backup(creds_backup)
+            except CalledProcessError:
+                pass
+
+        # Installing the auto-reload hook is non-fatal: the certificate is issued
+        # and HTTPS will work; the (idempotent) hook can be added on a re-run.
+        try:
+            install_renew_hook()
+        except CalledProcessError:
+            Logger.print_dialog(
+                DialogType.WARNING,
+                [
+                    "The certificate was issued, but installing the nginx "
+                    "auto-reload hook for renewals failed.",
+                    "HTTPS will still be enabled; re-run 'Enable HTTPS' later to "
+                    "add the hook.",
+                ],
+            )
+
+        if not self._apply_nginx_config(site, new_config):
+            return
+
+        Logger.print_dialog(
+            DialogType.SUCCESS,
+            [
+                f"HTTPS enabled for {client.display_name}!",
+                f"Open it now on: https://{fqdn}",
+                "\n\n",
+                "Disable HTTPS before using 'Reconfigure Listen Port'.",
+                "If a cross-origin client is blocked after the switch, add "
+                f"'*://{fqdn}' to cors_domains in moonraker.conf.",
+            ],
+            center_content=True,
+        )
+
+    def remove_extension(self, **kwargs) -> None:
+        client = self._select_client()
+        if client is None:
+            return
+
+        site: Path = client.nginx_config
+        current = self._read_site(site)
+        if current is None:
+            return
+
+        if not config_enables_https(current):
+            Logger.print_dialog(
+                DialogType.INFO,
+                [f"HTTPS is not enabled for {client.display_name}."],
+            )
+            return
+
+        fqdn = extract_fqdn(current)
+        # restore the port the site was actually on (recorded in the redirect
+        # block). Fall back to KIAUH settings if it cannot be read, or if it
+        # comes back as 443 - a site configured outside this extension may not
+        # have our redirect/TLS layout, and rebuilding plain HTTP on 443 would
+        # be wrong.
+        port = extract_redirect_port(current)
+        if port is None or port == HTTPS_PORT:
+            port = int(KiauhSettings().get(client.name, "port"))
+
+        # reverse the install transform instead of regenerating from the stock
+        # template, so any customizations carried into the TLS block survive
+        http_config = build_http_config(current, port)
+
+        Logger.print_status(
+            f"Restoring plain HTTP config for {client.display_name} ..."
+        )
+        if not self._apply_nginx_config(site, http_config):
+            return
+
+        cleanup = [
+            f"HTTPS disabled for {client.display_name}; it now serves plain HTTP.",
+            "The certificate and DNS credentials were kept. To remove them:",
+        ]
+        if fqdn is not None:
+            cleanup.append(f"  sudo certbot delete --cert-name {fqdn}")
+            cleanup.append(f"  sudo rm /root/.secrets/{fqdn}.ini")
+        else:
+            cleanup.append("  sudo rm /root/.secrets/<fqdn>.ini")
+        Logger.print_dialog(DialogType.ATTENTION, cleanup)
+
+    # --------------------------------------------------------------------- #
+    # helpers
+    # --------------------------------------------------------------------- #
+    def _port_443_in_use(self) -> bool:
+        """
+        True if any enabled nginx site already has an active listen on port 443
+        (TLS or plain). Scans every listen directive of every enabled config -
+        not just the last listen per file - so a 443 directive followed by
+        another listen, or a non-TLS ``listen 443;``, is still detected.
+
+        Limitation: this only inspects nginx's own enabled sites. A non-nginx
+        daemon holding port 443 (Caddy, Apache, ...) is not seen here, and since
+        a reload can succeed without the socket actually binding, the install
+        could report success while HTTPS is not live. Detecting that reliably
+        needs OS-level socket inspection, which is out of scope for this helper.
+        """
+        for cfg in get_nginx_config_list():
+            try:
+                if HTTPS_PORT in listen_ports(cfg.read_text()):
+                    return True
+            except OSError:
+                continue
+        return False
+
+    def _distro_supported(self) -> bool:
+        try:
+            distro_id, _ = get_distro_info()
+        except (ValueError, OSError, CalledProcessError):
+            # get_distro_info shells out via `cat /etc/os-release`; a missing
+            # file makes it exit non-zero (CalledProcessError), which is not an
+            # OSError - treat any lookup failure as "unsupported", not a crash.
+            distro_id = ""
+        if distro_id in SUPPORTED_DISTRO_IDS:
+            return True
+        Logger.print_dialog(
+            DialogType.ERROR,
+            ["This feature requires a Debian-based system (apt + certbot)."],
+        )
+        return False
+
+    def _select_client(self) -> Optional[BaseWebClient]:
+        clients: List[BaseWebClient] = get_existing_clients()
+        if not clients:
+            Logger.print_dialog(
+                DialogType.ERROR,
+                ["No Mainsail or Fluidd installation was found."],
+            )
+            return None
+        if len(clients) == 1:
+            return clients[0]
+
+        options = {str(i): c for i, c in enumerate(clients, start=1)}
+        Logger.print_dialog(
+            DialogType.INFO,
+            ["Multiple clients found. Select the one to enable HTTPS for:"]
+            + [f"{i}) {c.display_name}" for i, c in options.items()],
+        )
+        choice = get_selection_input("Select client", list(options.keys()))
+        return options[choice]
+
+    def _select_provider(self) -> DnsProvider:
+        options = {str(i): key for i, key in enumerate(PROVIDERS, start=1)}
+        Logger.print_dialog(
+            DialogType.INFO,
+            ["Select your DNS provider (its API hosts the DNS-01 challenge):"]
+            + [f"{i}) {PROVIDERS[key].display_name}" for i, key in options.items()],
+        )
+        choice = get_selection_input("Select DNS provider", list(options.keys()))
+        return PROVIDERS[options[choice]]
+
+    def _prompt_credentials(self, provider: DnsProvider) -> Dict[str, str]:
+        values: Dict[str, str] = {}
+        for field in provider.credentials_fields:
+            if field.secret:
+                values[field.ini_key] = get_secret_input(field.prompt)
+            else:
+                # non-secret fields (zone ids, account names, API versions) may
+                # contain '-', '_', '.' or '/', so do not restrict to alnum
+                values[field.ini_key] = get_string_input(
+                    field.prompt,
+                    allow_special_chars=True,
+                    default=field.default,
+                )
+        return values
+
+    def _undo_credentials(
+        self,
+        reuse: bool,
+        existed: bool,
+        backup: Optional[Path],
+        fqdn: str,
+    ) -> None:
+        """
+        Roll back the credentials change after a FAILED issuance, best-effort so
+        a failing cleanup never masks the real error.
+
+        * reuse: nothing was changed, nothing to undo.
+        * a backup exists (we replaced a working file): restore it, so the
+          retained certificate keeps renewing with its known-good credentials.
+        * first-time write (no prior file): remove the token we wrote.
+        * replaced a file we could not back up: leave the new file - it is the
+          only one left, so deleting it would strand the retained certificate.
+        """
+        try:
+            if reuse:
+                return
+            if backup is not None:
+                restore_credentials(backup, fqdn)
+            elif not existed:
+                remove_credentials(credentials_file(fqdn))
+        except CalledProcessError:
+            pass
+
+    def _print_summary(
+        self,
+        client: BaseWebClient,
+        provider: DnsProvider,
+        fqdn: str,
+        reusing_credentials: bool = False,
+    ) -> None:
+        lines = [
+            "About to request a certificate and enable HTTPS:",
+            f"● Client:    {client.display_name}",
+            f"● Domain:    {fqdn}",
+            f"● Provider:  {provider.display_name}",
+            "\n\n",
+        ]
+        if reusing_credentials:
+            lines.append(
+                f"Existing credentials for {fqdn} are reused; no token is needed."
+            )
+        else:
+            cred_file = (
+                f"{fqdn}.ini" if provider.credentials_filename else "(environment)"
+            )
+            lines.append(
+                f"The API token is stored only in /root/.secrets/{cred_file} "
+                "(chmod 600) and never in KIAUH config or git."
+            )
+        Logger.print_dialog(DialogType.WARNING, lines)
+
+    def _read_site(self, site: Path) -> Optional[str]:
+        try:
+            return site.read_text()
+        except OSError:
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [f"Could not read the nginx site at {site}."],
+            )
+            return None
+
+    def _build_https_config(
+        self, current: str, fqdn: str, redirect_port: int
+    ) -> Optional[str]:
+        """
+        Build the rewritten HTTPS config from the current site, or return None
+        (after a clean error dialog) if the site cannot be rewritten. Pure - no
+        I/O - so it is safe to call before any certificate is issued.
+        """
+        full, key = cert_paths(fqdn)
+        try:
+            config: str = build_https_config(
+                current, fqdn, str(full), str(key), redirect_port=redirect_port
+            )
+            return config
+        except (ValueError, AlreadyHttpsError):
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    "Could not rewrite the existing nginx site for HTTPS.",
+                    "The site was left unchanged.",
+                ],
+            )
+            return None
+
+    def _apply_nginx_config(self, site: Path, new_config: str) -> bool:
+        """
+        Apply a rewritten nginx site transactionally (used for both enabling and
+        disabling HTTPS): back up, write, validate, then reload - or restore the
+        backup if nginx -t fails or any privileged step errors. Returns True only
+        when the new config is live and valid.
+        """
+        try:
+            backup = backup_site(site)
+        except CalledProcessError:
+            # the backup itself failed; nothing was written, so leave the live
+            # site as-is rather than crash or restore an unrelated stale backup.
+            Logger.print_dialog(
+                DialogType.ERROR,
+                ["Could not back up the nginx site; it was left unchanged."],
+            )
+            return False
+
+        try:
+            write_site(site, new_config)
+            if not nginx_config_test():
+                Logger.print_error("nginx rejected the new config; reverting ...")
+                restore_site(backup, site)
+                reload_nginx()
+                discard_backup(backup)
+                Logger.print_dialog(
+                    DialogType.ERROR,
+                    [
+                        "The generated config failed nginx -t. Reverted to the "
+                        "previous site."
+                    ],
+                )
+                return False
+            reload_nginx()
+        except CalledProcessError:
+            # a privileged step after the backup (write/test/reload/restore)
+            # shells out with check=True; on failure restore THIS transaction's
+            # backup - not whatever .bak happens to be on disk - and surface one
+            # clean error rather than crash or leave a half-applied config.
+            self._revert_failed_apply(backup, site)
+            return False
+
+        # the new config is live and validated. Dropping the backup is best-
+        # effort cleanup: a failing 'rm' must NOT roll back the change just
+        # committed, so its error is swallowed here, not raised into the revert.
+        try:
+            discard_backup(backup)
+        except CalledProcessError:
+            pass
+        return True
+
+    def _revert_failed_apply(self, backup: Path, site: Path) -> None:
+        """
+        Restore from the backup taken by THIS apply call. The backup is dropped
+        ONLY after the restore succeeds, so a failed restore keeps the only
+        recovery copy instead of leaving a half-applied config with no backup.
+        """
+        try:
+            restore_site(backup, site)
+        except CalledProcessError:
+            # the restore itself failed - keep the backup as the only recovery
+            # copy and say so honestly rather than claim a clean rollback.
+            Logger.print_dialog(
+                DialogType.ERROR,
+                [
+                    "Failed to apply the nginx config and could not restore the "
+                    "previous site automatically.",
+                    f"A backup of the previous site is kept at {backup}.",
+                ],
+            )
+            return
+
+        # the previous site is back on disk; reload it and drop the now-redundant
+        # backup, both best-effort so a secondary failure is not fatal.
+        try:
+            reload_nginx()
+        except CalledProcessError:
+            pass
+        try:
+            discard_backup(backup)
+        except CalledProcessError:
+            pass
+        Logger.print_dialog(
+            DialogType.ERROR,
+            ["Failed to apply the nginx config; the previous site was restored."],
+        )

--- a/kiauh/extensions/https/metadata.json
+++ b/kiauh/extensions/https/metadata.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "index": 15,
+    "index": 17,
     "module": "https_extension",
     "maintained_by": "lexfrei",
     "display_name": "Enable HTTPS (Let's Encrypt / certbot DNS-01)",

--- a/kiauh/extensions/https/metadata.json
+++ b/kiauh/extensions/https/metadata.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "index": 15,
+    "module": "https_extension",
+    "maintained_by": "lexfrei",
+    "display_name": "Enable HTTPS (Let's Encrypt / certbot DNS-01)",
+    "description": [
+      "Obtain a Let's Encrypt certificate via certbot DNS-01 and reconfigure",
+      "the Mainsail/Fluidd nginx site for HTTPS.",
+      "- Works on LAN-only hosts (no public HTTP-01 reachability needed)",
+      "- Forces an HTTP -> HTTPS redirect and serves the UI on port 443",
+      "- Supported DNS providers: Cloudflare, DigitalOcean, Linode",
+      "\n\n",
+      "Requires a domain whose DNS is hosted by a supported provider and a scoped API token with DNS edit rights."
+    ],
+    "updates": false
+  }
+}

--- a/kiauh/extensions/https/nginx_https.py
+++ b/kiauh/extensions/https/nginx_https.py
@@ -1,0 +1,303 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+"""
+Pure (side-effect free) helpers that rewrite a KIAUH-generated nginx site
+from plain HTTP into an HTTP->HTTPS redirect plus a TLS server block.
+
+Nothing in this module touches the filesystem, subprocess, sudo or certbot.
+That keeps the actual config transformation fully unit-testable without a
+running nginx or a Debian host. The orchestration (certbot, sudo writes,
+nginx reload) lives in the surrounding extension modules.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from utils.nginx_utils import config_enables_https
+
+_SERVER_OPEN_RE = re.compile(r"\bserver\b[^{]*\{")
+_SERVER_NAME_RE = re.compile(r"^\s*server_name\s+(\S+)", re.MULTILINE)
+_LISTEN_PORT_RE = re.compile(r"^\s*listen\s+(\d+)\b", re.MULTILINE)
+_TLS_DIRECTIVE_RE = re.compile(
+    r"^\s*(ssl_certificate|ssl_certificate_key|ssl_protocols)\b"
+)
+
+
+class AlreadyHttpsError(Exception):
+    """Raised when the given config already contains a TLS server block."""
+
+
+def _mask_comments(config_text: str) -> str:
+    """
+    Return a copy of the config with every ``#`` comment (``#`` to end of line)
+    replaced by spaces, preserving length so offsets still map to the original.
+    Used to find block delimiters without matching ``server {`` or braces that
+    live inside a comment.
+    """
+    out = []
+    in_comment = False
+    for char in config_text:
+        if char == "\n":
+            in_comment = False
+            out.append(char)
+        elif char == "#":
+            in_comment = True
+            out.append(" ")
+        elif in_comment:
+            out.append(" ")
+        else:
+            out.append(char)
+    return "".join(out)
+
+
+def _server_bodies(config_text: str) -> list[str]:
+    """
+    Return the inner body of every top-level ``server { ... }`` block, in order
+    (the content between each block's outermost braces, exclusive). Nested
+    ``location { ... }`` blocks are preserved verbatim via depth counting, and
+    ``server {`` or braces appearing inside comments are ignored.
+
+    :raises ValueError: if a server block has unbalanced braces
+    """
+    # match delimiters on a comment-masked copy (same length, so indices map
+    # back), but slice the bodies from the original text to keep their comments.
+    masked = _mask_comments(config_text)
+    bodies: list[str] = []
+    pos = 0
+    while True:
+        match = _SERVER_OPEN_RE.search(masked, pos)
+        if match is None:
+            return bodies
+
+        open_idx = match.end() - 1  # index of the opening brace
+        depth = 0
+        end = None
+        for i in range(open_idx, len(masked)):
+            char = masked[i]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        if end is None:
+            raise ValueError("Unbalanced braces in server block.")
+        bodies.append(config_text[open_idx + 1 : end])
+        pos = end + 1
+
+
+def extract_server_body(config_text: str) -> str:
+    """
+    Return the inner body of the FIRST top-level ``server { ... }`` block.
+
+    :param config_text: the full nginx config text
+    :return: the inner body of the first server block
+    :raises ValueError: if no balanced server block can be found
+    """
+    bodies = _server_bodies(config_text)
+    if not bodies:
+        raise ValueError("No 'server { ... }' block found in config.")
+    return bodies[0]
+
+
+def extract_tls_server_body(config_text: str) -> str:
+    """
+    Return the inner body of the first top-level server block that has an
+    active ``listen ... 443 ssl`` directive - i.e. the TLS block in a
+    build_https_config output, as opposed to the :80 redirect block.
+
+    :param config_text: the full nginx config text
+    :return: the inner body of the TLS server block
+    :raises ValueError: if no TLS server block can be found
+    """
+    for body in _server_bodies(config_text):
+        if config_enables_https(body):
+            return body
+    raise ValueError("No TLS ('listen 443 ssl') server block found in config.")
+
+
+def strip_listen_directives(server_body: str) -> str:
+    """
+    Remove the directives that the new wrapper blocks supply themselves:
+    every ``listen ...;`` line (including the commented IPv6 variant KIAUH
+    emits and its helper comment) and the bare catch-all ``server_name _;``.
+
+    Leading and trailing blank lines are trimmed; interior formatting is kept.
+
+    :param server_body: the inner body of an nginx server block
+    :return: the cleaned body
+    """
+    kept = []
+    for line in server_body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("listen") or stripped.startswith("# listen"):
+            continue
+        if stripped == "# uncomment the next line to activate IPv6":
+            continue
+        if stripped == "server_name _;":
+            continue
+        kept.append(line)
+
+    return "\n".join(kept).strip("\n")
+
+
+def build_https_config(
+    original_config_text: str,
+    fqdn: str,
+    cert_path: str,
+    key_path: str,
+    redirect_port: int = 80,
+) -> str:
+    """
+    Rewrite a plain-HTTP KIAUH nginx site into two server blocks:
+
+      * a ``listen <redirect_port>`` block that does nothing but
+        ``return 301 https://$host$request_uri;`` (no location blocks, so
+        EVERY path redirects), and
+      * a ``listen 443 ssl http2`` block carrying the original body
+        (root + all proxy/location blocks) with the TLS directives injected.
+
+    Only the FIRST top-level ``server`` block is rewritten and its body is
+    carried over verbatim (gzip, proxy and webcam directives included); any
+    content outside it is dropped. This holds for KIAUH's single-block
+    template - the source of this config - but is worth knowing if that
+    template ever grows a second server block.
+
+    :param original_config_text: the current (HTTP) nginx config text
+    :param fqdn: the fully qualified domain name for the certificate/site
+    :param cert_path: path to the fullchain.pem
+    :param key_path: path to the privkey.pem
+    :param redirect_port: the port the redirect block listens on (default 80)
+    :return: the rewritten config text
+    :raises AlreadyHttpsError: if the input already has a TLS server block
+    :raises ValueError: if no server block can be extracted
+    """
+    if config_enables_https(original_config_text):
+        raise AlreadyHttpsError("Config already contains a 'listen 443 ssl' block.")
+
+    body = strip_listen_directives(extract_server_body(original_config_text))
+
+    # IPv6 listen is emitted commented-out, mirroring KIAUH's own site
+    # template: an active 'listen [::]' aborts nginx -t on hosts where IPv6 is
+    # disabled. Users who want IPv6 uncomment it in both blocks.
+    # Redirect to the validated FQDN, not $host: the block also answers the
+    # catch-all server_name '_', so reflecting an attacker-supplied Host header
+    # through $host would be an open redirect. The certificate is only valid for
+    # fqdn anyway, so the canonical target is always correct.
+    redirect_block = (
+        "server {\n"
+        f"    listen {redirect_port};\n"
+        "    # uncomment the next line to activate IPv6\n"
+        f"    # listen [::]:{redirect_port};\n"
+        f"    server_name {fqdn} _;\n"
+        f"    return 301 https://{fqdn}$request_uri;\n"
+        "}\n"
+    )
+
+    tls_block = (
+        "server {\n"
+        "    listen 443 ssl http2;\n"
+        "    # uncomment the next line to activate IPv6\n"
+        "    # listen [::]:443 ssl http2;\n"
+        f"    server_name {fqdn} _;\n"
+        "\n"
+        f"    ssl_certificate {cert_path};\n"
+        f"    ssl_certificate_key {key_path};\n"
+        "    ssl_protocols TLSv1.2 TLSv1.3;\n"
+        "\n"
+        f"{body}\n"
+        "}\n"
+    )
+
+    return f"{redirect_block}\n{tls_block}"
+
+
+def build_http_config(https_config_text: str, port: int = 80) -> str:
+    """
+    Reverse of build_https_config: rebuild a single plain-HTTP server block
+    from an HTTPS config, carrying the body (root, proxy/location blocks, gzip,
+    any custom directives) back over verbatim.
+
+    The transform is purely subtractive: from the TLS server block it drops only
+    the directives this extension injected - the ``listen ... 443 ssl`` lines
+    (and the commented IPv6 variant), the ``ssl_certificate``/
+    ``ssl_certificate_key``/``ssl_protocols`` lines, and the catch-all
+    ``server_name <fqdn> _;`` it added - and keeps everything else. So disabling
+    HTTPS no longer resets the site to KIAUH's stock template and preserves a
+    user's customizations. The :80 redirect block is discarded.
+
+    :param https_config_text: the current HTTPS nginx config text
+    :param port: the plain-HTTP listen port to restore
+    :return: the rebuilt HTTP config text
+    :raises ValueError: if no TLS server block can be found
+    """
+    fqdn = extract_fqdn(https_config_text)
+    tls_body = extract_tls_server_body(https_config_text)
+    injected_server_name = f"server_name {fqdn} _;" if fqdn else None
+
+    kept = []
+    for line in tls_body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("listen") or stripped.startswith("# listen"):
+            continue
+        if stripped == "# uncomment the next line to activate IPv6":
+            continue
+        if _TLS_DIRECTIVE_RE.match(line):
+            continue
+        if injected_server_name is not None and stripped == injected_server_name:
+            continue
+        kept.append(line)
+    body = "\n".join(kept).strip("\n")
+
+    return (
+        "server {\n"
+        f"    listen {port};\n"
+        "    # uncomment the next line to activate IPv6\n"
+        f"    # listen [::]:{port};\n"
+        "\n"
+        f"{body}\n"
+        "}\n"
+    )
+
+
+def extract_fqdn(config_text: str) -> Optional[str]:
+    """
+    Return the first concrete ``server_name`` token (the FQDN) from a config,
+    skipping the catch-all ``_``. Returns None if only the catch-all is set,
+    as in a freshly generated HTTP site.
+
+    :param config_text: the full nginx config text
+    :return: the FQDN, or None if not present
+    """
+    for match in _SERVER_NAME_RE.finditer(config_text):
+        name = match.group(1).rstrip(";")
+        if name and name != "_":
+            return name
+    return None
+
+
+def extract_redirect_port(config_text: str) -> Optional[int]:
+    """
+    Return the listen port of the FIRST server block. In a config produced by
+    build_https_config that is the HTTP redirect block, so this recovers the
+    port the site was on before HTTPS - used to restore it on disable. Returns
+    None if the first block has no numeric listen.
+
+    :param config_text: the full nginx config text
+    :return: the redirect (original HTTP) port, or None
+    """
+    try:
+        body = extract_server_body(config_text)
+    except ValueError:
+        return None
+    match = _LISTEN_PORT_RE.search(body)
+    return int(match.group(1)) if match else None

--- a/kiauh/extensions/https/nginx_ops.py
+++ b/kiauh/extensions/https/nginx_ops.py
@@ -1,0 +1,74 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+"""
+Privileged nginx site operations used to apply an HTTPS rewrite transactionally.
+
+These wrap sudo + subprocess so the orchestration can back up the current
+site, write the new one, validate it with `nginx -t`, and either reload or
+restore the backup - never leaving nginx with a config it cannot load.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import DEVNULL, PIPE, run
+
+from core.logger import Logger
+from utils.sys_utils import cmd_sysctl_service
+
+BACKUP_SUFFIX = ".kiauh.bak"
+
+
+def backup_site(site: Path) -> Path:
+    """Copy the (root-owned) nginx site to a sibling backup and return it."""
+    backup: Path = site.parent.joinpath(site.name + BACKUP_SUFFIX)
+    run(["sudo", "cp", str(site), str(backup)], stderr=PIPE, check=True)
+    return backup
+
+
+def discard_backup(backup: Path) -> None:
+    """
+    Remove a site backup created by backup_site. Idempotent (``rm -f``) so it
+    is safe to call even if a previous run already cleaned it up. Leaving the
+    backup behind would litter the nginx config directory with a stale site.
+    """
+    run(["sudo", "rm", "-f", str(backup)], stderr=PIPE, check=True)
+
+
+def write_site(site: Path, content: str) -> None:
+    """Write `content` to the root-owned nginx site via `sudo tee`."""
+    run(
+        ["sudo", "tee", str(site)],
+        input=content.encode(),
+        stdout=DEVNULL,
+        stderr=PIPE,
+        check=True,
+    )
+
+
+def restore_site(backup: Path, site: Path) -> None:
+    """Restore a previously created backup over the live nginx site."""
+    run(["sudo", "cp", str(backup), str(site)], stderr=PIPE, check=True)
+
+
+def nginx_config_test() -> bool:
+    """
+    Return True if `nginx -t` reports the current configuration is valid.
+    On failure the nginx error (which names the offending line) is logged so
+    a rejected rewrite is diagnosable instead of silently swallowed.
+    """
+    result = run(["sudo", "nginx", "-t"], stdout=PIPE, stderr=PIPE)
+    if result.returncode != 0 and result.stderr:
+        Logger.print_error(result.stderr.decode(errors="replace").strip(), False)
+    return result.returncode == 0
+
+
+def reload_nginx() -> None:
+    """Gracefully reload nginx so it picks up the new site configuration."""
+    cmd_sysctl_service("nginx", "reload")

--- a/kiauh/extensions/https/providers.py
+++ b/kiauh/extensions/https/providers.py
@@ -1,0 +1,163 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+"""
+DNS provider definitions for certbot DNS-01 issuance.
+
+A provider is pure data describing how to drive its certbot plugin: the apt
+package, the certbot flags, and the credentials-file fields. The certbot
+command and credentials-file body are assembled generically from that data,
+so adding a provider is a single dict entry. The credentials/propagation
+flags are optional, leaving room for a future env/IAM-based provider (e.g.
+Route53) that has no credentials file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class CredField:
+    """A single line of a certbot DNS plugin credentials (.ini) file."""
+
+    ini_key: str
+    prompt: str
+    secret: bool = True
+    default: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DnsProvider:
+    """How to obtain a DNS-01 certificate through one certbot DNS plugin."""
+
+    key: str
+    display_name: str
+    plugin_package: str
+    plugin_flag: str
+    credentials_fields: List[CredField]
+    credentials_flag: Optional[str] = None
+    propagation_flag: Optional[str] = None
+    default_propagation: int = 30
+    credentials_filename: Optional[str] = None
+
+
+PROVIDERS: Dict[str, DnsProvider] = {
+    "cloudflare": DnsProvider(
+        key="cloudflare",
+        display_name="Cloudflare",
+        plugin_package="python3-certbot-dns-cloudflare",
+        plugin_flag="--dns-cloudflare",
+        credentials_flag="--dns-cloudflare-credentials",
+        propagation_flag="--dns-cloudflare-propagation-seconds",
+        default_propagation=30,
+        credentials_filename="cloudflare.ini",
+        credentials_fields=[
+            CredField(
+                ini_key="dns_cloudflare_api_token",
+                prompt="Cloudflare API token (Zone:DNS:Edit)",
+            ),
+        ],
+    ),
+    "digitalocean": DnsProvider(
+        key="digitalocean",
+        display_name="DigitalOcean",
+        plugin_package="python3-certbot-dns-digitalocean",
+        plugin_flag="--dns-digitalocean",
+        credentials_flag="--dns-digitalocean-credentials",
+        propagation_flag="--dns-digitalocean-propagation-seconds",
+        default_propagation=30,
+        credentials_filename="digitalocean.ini",
+        credentials_fields=[
+            CredField(
+                ini_key="dns_digitalocean_token",
+                prompt="DigitalOcean API token (read & write)",
+            ),
+        ],
+    ),
+    "linode": DnsProvider(
+        key="linode",
+        display_name="Linode",
+        plugin_package="python3-certbot-dns-linode",
+        plugin_flag="--dns-linode",
+        credentials_flag="--dns-linode-credentials",
+        propagation_flag="--dns-linode-propagation-seconds",
+        # Linode refreshes its DNS every 60s; the plugin default of 120 leaves
+        # margin for that update to reach the authoritative servers.
+        default_propagation=120,
+        credentials_filename="linode.ini",
+        credentials_fields=[
+            CredField(ini_key="dns_linode_key", prompt="Linode API key"),
+            CredField(
+                ini_key="dns_linode_version",
+                prompt="Linode API version",
+                secret=False,
+                default="4",
+            ),
+        ],
+    ),
+}
+
+
+def build_certbot_command(
+    provider: DnsProvider,
+    fqdn: str,
+    email: str,
+    propagation_seconds: int,
+    credentials_path: Optional[str] = None,
+    force_renewal: bool = False,
+) -> List[str]:
+    """
+    Assemble the ``certbot certonly`` argv for a DNS-01 issuance.
+
+    The credentials/propagation flags are included only when the provider
+    declares them (and, for credentials, a path is given), so a provider
+    without a credentials file composes without special-casing. All flags are
+    long form on purpose; the secret never appears here - only the path to the
+    credentials file does.
+
+    With ``force_renewal`` certbot runs a real DNS challenge instead of keeping
+    an unexpired certificate: used when replacing credentials, so the new token
+    is actually validated rather than silently accepted by --keep-until-expiring.
+    """
+    cmd: List[str] = ["sudo", "certbot", "certonly", provider.plugin_flag]
+    if provider.credentials_flag and credentials_path:
+        cmd += [provider.credentials_flag, credentials_path]
+    if provider.propagation_flag:
+        cmd += [provider.propagation_flag, str(propagation_seconds)]
+    cmd += [
+        "--domain",
+        fqdn,
+        "--non-interactive",
+        "--agree-tos",
+        "--email",
+        email,
+        # opt out of the EFF mailing list explicitly: with --non-interactive
+        # certbot cannot ask, and we must not silently subscribe the user.
+        "--no-eff-email",
+        "--force-renewal" if force_renewal else "--keep-until-expiring",
+    ]
+    return cmd
+
+
+def build_credentials_content(provider: DnsProvider, values: Dict[str, str]) -> str:
+    """
+    Render the INI credentials-file body for the provider from a mapping of
+    ``ini_key -> value``. Only the provider's declared fields are written.
+
+    Each value is stripped here - this is the single, deliberate point where a
+    credential is normalized. ``get_secret_input`` returns the raw input, so
+    trimming an accidental trailing newline from a paste happens at write time;
+    DNS API tokens never carry significant leading/trailing whitespace.
+    """
+    lines = [
+        f"{f.ini_key} = {values[f.ini_key].strip()}"
+        for f in provider.credentials_fields
+    ]
+    return "\n".join(lines) + "\n"

--- a/kiauh/extensions/https/tests/__init__.py
+++ b/kiauh/extensions/https/tests/__init__.py
@@ -1,0 +1,8 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #

--- a/kiauh/extensions/https/tests/assets/expected_https_cfg
+++ b/kiauh/extensions/https/tests/assets/expected_https_cfg
@@ -1,0 +1,107 @@
+server {
+    listen 80;
+    # uncomment the next line to activate IPv6
+    # listen [::]:80;
+    server_name printer.example.com _;
+    return 301 https://printer.example.com$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    # uncomment the next line to activate IPv6
+    # listen [::]:443 ssl http2;
+    server_name printer.example.com _;
+
+    ssl_certificate /etc/letsencrypt/live/printer.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/printer.example.com/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    access_log /var/log/nginx/mainsail-access.log;
+    error_log /var/log/nginx/mainsail-error.log;
+
+    # disable this section on smaller hardware like a pi zero
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_comp_level 4;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/json application/xml;
+
+    # web_path from mainsail static files
+    root /home/pi/mainsail;
+
+    index index.html;
+
+    # disable max upload size checks
+    client_max_body_size 0;
+
+    # disable proxy request buffering
+    proxy_request_buffering off;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    location /websocket {
+        proxy_pass http://apiserver/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 86400;
+    }
+
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://apiserver$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    location /webcam/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer1/;
+    }
+
+    location /webcam2/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer2/;
+    }
+
+    location /webcam3/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer3/;
+    }
+
+    location /webcam4/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer4/;
+    }
+}

--- a/kiauh/extensions/https/tests/assets/mainsail_http_cfg
+++ b/kiauh/extensions/https/tests/assets/mainsail_http_cfg
@@ -1,0 +1,95 @@
+server {
+    listen 80;
+    # uncomment the next line to activate IPv6
+    # listen [::]:80;
+
+    access_log /var/log/nginx/mainsail-access.log;
+    error_log /var/log/nginx/mainsail-error.log;
+
+    # disable this section on smaller hardware like a pi zero
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_comp_level 4;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/json application/xml;
+
+    # web_path from mainsail static files
+    root /home/pi/mainsail;
+
+    index index.html;
+    server_name _;
+
+    # disable max upload size checks
+    client_max_body_size 0;
+
+    # disable proxy request buffering
+    proxy_request_buffering off;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    location /websocket {
+        proxy_pass http://apiserver/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 86400;
+    }
+
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://apiserver$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    location /webcam/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer1/;
+    }
+
+    location /webcam2/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer2/;
+    }
+
+    location /webcam3/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer3/;
+    }
+
+    location /webcam4/ {
+        postpone_output 0;
+        proxy_buffering off;
+        proxy_ignore_headers X-Accel-Buffering;
+        access_log off;
+        error_log off;
+        proxy_pass http://mjpgstreamer4/;
+    }
+}

--- a/kiauh/extensions/https/tests/conftest.py
+++ b/kiauh/extensions/https/tests/conftest.py
@@ -1,0 +1,25 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from pathlib import Path
+
+import pytest
+
+ASSETS_DIR = Path(__file__).parent.joinpath("assets")
+
+
+@pytest.fixture()
+def http_config_text() -> str:
+    """The nginx config KIAUH generates for a Mainsail install on port 80."""
+    return ASSETS_DIR.joinpath("mainsail_http_cfg").read_text()
+
+
+@pytest.fixture()
+def expected_https_text() -> str:
+    """Golden output of build_https_config for the http_config_text fixture."""
+    return ASSETS_DIR.joinpath("expected_https_cfg").read_text()

--- a/kiauh/extensions/https/tests/test_certbot.py
+++ b/kiauh/extensions/https/tests/test_certbot.py
@@ -1,0 +1,288 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from pathlib import Path
+from subprocess import CalledProcessError
+from unittest.mock import patch
+
+import pytest
+from extensions.https import LE_LIVE_DIR, RENEWAL_HOOK_DIR, SECRETS_DIR
+from extensions.https.certbot import (
+    backup_credentials,
+    cert_paths,
+    credentials_exist,
+    credentials_match_provider,
+    discard_credentials_backup,
+    ensure_certbot,
+    install_renew_hook,
+    remove_credentials,
+    restore_credentials,
+    run_certbot,
+    write_credentials,
+)
+from extensions.https.providers import PROVIDERS
+
+TOKEN = "supersecret-cloudflare-token"
+
+
+def _argv_list(mock_run):
+    """All positional command lists passed to the mocked run()."""
+    return [call.args[0] for call in mock_run.call_args_list]
+
+
+def _flat_argv(mock_run):
+    return [tok for argv in _argv_list(mock_run) for tok in argv]
+
+
+# --------------------------------------------------------------------------- #
+# cert_paths
+# --------------------------------------------------------------------------- #
+def test_cert_paths():
+    full, key = cert_paths("printer.example.com")
+    assert full == LE_LIVE_DIR.joinpath("printer.example.com", "fullchain.pem")
+    assert key == LE_LIVE_DIR.joinpath("printer.example.com", "privkey.pem")
+
+
+# --------------------------------------------------------------------------- #
+# ensure_certbot
+# --------------------------------------------------------------------------- #
+def test_ensure_certbot_installs_missing():
+    missing = ["certbot", "python3-certbot-dns-cloudflare"]
+    with patch("extensions.https.certbot.check_package_install", return_value=missing):
+        with patch("extensions.https.certbot.install_system_packages") as install:
+            ensure_certbot(PROVIDERS["cloudflare"])
+    install.assert_called_once()
+    assert "certbot" in install.call_args.args[0]
+
+
+def test_ensure_certbot_skips_when_present():
+    with patch("extensions.https.certbot.check_package_install", return_value=[]):
+        with patch("extensions.https.certbot.install_system_packages") as install:
+            ensure_certbot(PROVIDERS["cloudflare"])
+    install.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# write_credentials
+# --------------------------------------------------------------------------- #
+def test_write_credentials_uses_sudo_tee_and_locks_down_perms():
+    with patch("extensions.https.certbot.run") as mock_run:
+        target = write_credentials(
+            PROVIDERS["cloudflare"],
+            {"dns_cloudflare_api_token": TOKEN},
+            "printer.example.com",
+        )
+
+    # the credentials file is named per certificate, not per provider
+    assert target == SECRETS_DIR.joinpath("printer.example.com.ini")
+    argvs = _argv_list(mock_run)
+    # the secrets dir is created and locked to 700
+    assert ["sudo", "mkdir", "-p", str(SECRETS_DIR)] in argvs
+    assert ["sudo", "chmod", "700", str(SECRETS_DIR)] in argvs
+    # the file is written via `sudo tee` and locked to 600
+    tee = [a for a in argvs if a[:2] == ["sudo", "tee"]]
+    assert tee == [["sudo", "tee", str(target)]]
+    assert ["sudo", "chmod", "600", str(target)] in argvs
+
+
+def test_write_credentials_passes_secret_via_stdin_only():
+    with patch("extensions.https.certbot.run") as mock_run:
+        write_credentials(
+            PROVIDERS["cloudflare"],
+            {"dns_cloudflare_api_token": TOKEN},
+            "printer.example.com",
+        )
+
+    # the token reaches tee only through input=, never as a command argument
+    assert TOKEN not in _flat_argv(mock_run)
+    tee_call = next(
+        c for c in mock_run.call_args_list if c.args[0][:2] == ["sudo", "tee"]
+    )
+    assert TOKEN.encode() in tee_call.kwargs["input"]
+
+
+def test_write_credentials_never_logs_secret():
+    creds = {"dns_cloudflare_api_token": TOKEN}
+    with patch("extensions.https.certbot.run"):
+        with patch("extensions.https.certbot.Logger") as logger:
+            write_credentials(PROVIDERS["cloudflare"], creds, "printer.example.com")
+
+    logged = " ".join(str(arg) for call in logger.method_calls for arg in call.args)
+    assert TOKEN not in logged
+
+
+def test_remove_credentials_uses_sudo_rm():
+    with patch("extensions.https.certbot.run") as mock_run:
+        remove_credentials(Path("/root/.secrets/cloudflare.ini"))
+    assert mock_run.call_args.args[0] == [
+        "sudo",
+        "rm",
+        "-f",
+        "/root/.secrets/cloudflare.ini",
+    ]
+
+
+def test_write_credentials_requires_a_credentials_file():
+    provider = PROVIDERS["cloudflare"].__class__(
+        key="envprov",
+        display_name="EnvProvider",
+        plugin_package="python3-certbot-dns-envprov",
+        plugin_flag="--dns-envprov",
+        credentials_fields=PROVIDERS["cloudflare"].credentials_fields,
+        credentials_filename=None,
+    )
+    with patch("extensions.https.certbot.run"):
+        with pytest.raises(ValueError):
+            write_credentials(
+                provider, {"dns_cloudflare_api_token": TOKEN}, "printer.example.com"
+            )
+
+
+def test_credentials_exist_true_when_present():
+    with patch("extensions.https.certbot.run") as mock_run:
+        mock_run.return_value.returncode = 0  # `sudo test -f` -> found
+        assert credentials_exist("printer.example.com") is True
+    assert mock_run.call_args.args[0] == [
+        "sudo",
+        "test",
+        "-f",
+        str(SECRETS_DIR.joinpath("printer.example.com.ini")),
+    ]
+
+
+def test_credentials_exist_false_when_absent():
+    with patch("extensions.https.certbot.run") as mock_run:
+        mock_run.return_value.returncode = 1  # `sudo test -f` -> not found
+        assert credentials_exist("printer.example.com") is False
+
+
+def test_credentials_match_provider_true_when_key_present():
+    with patch("extensions.https.certbot.run") as mock_run:
+        mock_run.return_value.returncode = 0  # grep found the provider's key
+        assert (
+            credentials_match_provider("printer.example.com", PROVIDERS["cloudflare"])
+            is True
+        )
+    argv = mock_run.call_args.args[0]
+    assert argv[:3] == ["sudo", "grep", "-q"]
+    # grep matches on the key NAME, never the secret value
+    assert "dns_cloudflare_api_token" in argv
+    assert str(SECRETS_DIR.joinpath("printer.example.com.ini")) in argv
+
+
+def test_credentials_match_provider_false_when_key_absent():
+    with patch("extensions.https.certbot.run") as mock_run:
+        mock_run.return_value.returncode = 1  # a different provider's file
+        assert (
+            credentials_match_provider("printer.example.com", PROVIDERS["linode"])
+            is False
+        )
+
+
+def test_backup_credentials_copies_to_bak():
+    with patch("extensions.https.certbot.run") as mock_run:
+        result = backup_credentials("printer.example.com")
+    assert result == SECRETS_DIR.joinpath("printer.example.com.ini.bak")
+    assert mock_run.call_args.args[0] == [
+        "sudo",
+        "cp",
+        "-p",
+        str(SECRETS_DIR.joinpath("printer.example.com.ini")),
+        str(SECRETS_DIR.joinpath("printer.example.com.ini.bak")),
+    ]
+
+
+def test_restore_credentials_moves_backup_into_place():
+    backup = SECRETS_DIR.joinpath("printer.example.com.ini.bak")
+    with patch("extensions.https.certbot.run") as mock_run:
+        restore_credentials(backup, "printer.example.com")
+    assert mock_run.call_args.args[0] == [
+        "sudo",
+        "mv",
+        str(backup),
+        str(SECRETS_DIR.joinpath("printer.example.com.ini")),
+    ]
+
+
+def test_discard_credentials_backup_uses_rm():
+    backup = SECRETS_DIR.joinpath("printer.example.com.ini.bak")
+    with patch("extensions.https.certbot.run") as mock_run:
+        discard_credentials_backup(backup)
+    assert mock_run.call_args.args[0] == ["sudo", "rm", "-f", str(backup)]
+
+
+def test_write_credentials_path_is_per_certificate():
+    # two certificates with the same provider must not share a credentials file,
+    # so issuing/removing one never clobbers another's renewal credentials
+    with patch("extensions.https.certbot.run"):
+        a = write_credentials(
+            PROVIDERS["cloudflare"],
+            {"dns_cloudflare_api_token": TOKEN},
+            "a.example.com",
+        )
+        b = write_credentials(
+            PROVIDERS["cloudflare"],
+            {"dns_cloudflare_api_token": TOKEN},
+            "b.example.com",
+        )
+    assert a == SECRETS_DIR.joinpath("a.example.com.ini")
+    assert b == SECRETS_DIR.joinpath("b.example.com.ini")
+    assert a != b
+
+
+# --------------------------------------------------------------------------- #
+# run_certbot
+# --------------------------------------------------------------------------- #
+def test_run_certbot_builds_expected_argv():
+    with patch("extensions.https.certbot.run") as mock_run:
+        run_certbot(
+            PROVIDERS["cloudflare"],
+            fqdn="printer.example.com",
+            email="me@example.com",
+            propagation_seconds=30,
+            credentials_path=Path("/root/.secrets/cloudflare.ini"),
+        )
+    argv = mock_run.call_args.args[0]
+    assert argv[:3] == ["sudo", "certbot", "certonly"]
+    assert "--dns-cloudflare" in argv
+    assert argv[argv.index("--domain") + 1] == "printer.example.com"
+    assert "--non-interactive" in argv
+
+
+def test_run_certbot_propagates_failure_without_touching_nginx():
+    with patch(
+        "extensions.https.certbot.run",
+        side_effect=CalledProcessError(1, "certbot"),
+    ) as mock_run:
+        with pytest.raises(CalledProcessError):
+            run_certbot(
+                PROVIDERS["cloudflare"],
+                "printer.example.com",
+                "me@example.com",
+                30,
+                Path("/root/.secrets/cloudflare.ini"),
+            )
+    # only certbot was invoked; nothing reloaded nginx
+    assert all("nginx" not in tok for tok in _flat_argv(mock_run))
+
+
+# --------------------------------------------------------------------------- #
+# install_renew_hook
+# --------------------------------------------------------------------------- #
+def test_install_renew_hook_writes_executable_reload_script():
+    with patch("extensions.https.certbot.run") as mock_run:
+        install_renew_hook()
+    argvs = _argv_list(mock_run)
+    assert ["sudo", "mkdir", "-p", str(RENEWAL_HOOK_DIR)] in argvs
+    tee_call = next(
+        c for c in mock_run.call_args_list if c.args[0][:2] == ["sudo", "tee"]
+    )
+    written = tee_call.kwargs["input"].decode()
+    assert "systemctl reload nginx" in written
+    target = tee_call.args[0][2]
+    assert ["sudo", "chmod", "0755", target] in argvs

--- a/kiauh/extensions/https/tests/test_https_extension.py
+++ b/kiauh/extensions/https/tests/test_https_extension.py
@@ -1,0 +1,601 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from pathlib import Path
+from subprocess import CalledProcessError
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from extensions.https.certbot import credentials_file
+from extensions.https.https_extension import HttpsExtension
+from extensions.https.nginx_https import build_https_config
+from extensions.https.providers import CredField, DnsProvider
+from utils.nginx_utils import config_enables_https
+
+MODULE = "extensions.https.https_extension"
+FQDN = "printer.example.com"
+FULLCHAIN = f"/etc/letsencrypt/live/{FQDN}/fullchain.pem"
+PRIVKEY = f"/etc/letsencrypt/live/{FQDN}/privkey.pem"
+
+
+@pytest.fixture()
+def env(monkeypatch, tmp_path, http_config_text):
+    """Patch every privileged seam and return the mocks plus a fake client."""
+    site = tmp_path.joinpath("mainsail")
+    site.write_text(http_config_text)
+
+    # a fake sites-enabled dir with the client's site present, so the
+    # "is the site enabled?" guard passes by default
+    sites_enabled = tmp_path.joinpath("sites-enabled")
+    sites_enabled.mkdir()
+    sites_enabled.joinpath("mainsail").write_text("")
+    monkeypatch.setattr(f"{MODULE}.NGINX_SITES_ENABLED", sites_enabled)
+
+    client = SimpleNamespace(
+        name="mainsail",
+        display_name="Mainsail",
+        nginx_config=site,
+        client_dir=Path("/home/pi/mainsail"),
+    )
+
+    def fake_backup(s: Path) -> Path:
+        bak = Path(str(s) + ".kiauh.bak")
+        bak.write_text(Path(s).read_text())
+        return bak
+
+    def fake_write_site(s: Path, content: str) -> None:
+        Path(s).write_text(content)
+
+    def fake_restore(bak: Path, s: Path) -> None:
+        Path(s).write_text(Path(bak).read_text())
+
+    def fake_discard(bak: Path) -> None:
+        Path(bak).unlink(missing_ok=True)
+
+    mocks = SimpleNamespace(
+        site=site,
+        sites_enabled=sites_enabled,
+        client=client,
+        get_distro_info=MagicMock(return_value=("debian", "12")),
+        get_existing_clients=MagicMock(return_value=[client]),
+        get_nginx_config_list=MagicMock(return_value=[]),
+        ensure_certbot=MagicMock(),
+        write_credentials=MagicMock(return_value=Path("/root/.secrets/cloudflare.ini")),
+        remove_credentials=MagicMock(),
+        credentials_exist=MagicMock(return_value=False),
+        credentials_match_provider=MagicMock(return_value=True),
+        backup_credentials=MagicMock(
+            return_value=Path("/root/.secrets/printer.example.com.ini.bak")
+        ),
+        restore_credentials=MagicMock(),
+        discard_credentials_backup=MagicMock(),
+        run_certbot=MagicMock(),
+        install_renew_hook=MagicMock(),
+        cert_paths=MagicMock(return_value=(Path(FULLCHAIN), Path(PRIVKEY))),
+        backup_site=MagicMock(side_effect=fake_backup),
+        write_site=MagicMock(side_effect=fake_write_site),
+        restore_site=MagicMock(side_effect=fake_restore),
+        discard_backup=MagicMock(side_effect=fake_discard),
+        nginx_config_test=MagicMock(return_value=True),
+        reload_nginx=MagicMock(),
+        get_string_input=MagicMock(side_effect=[FQDN, "me@example.com"]),
+        get_secret_input=MagicMock(return_value="secret-token"),
+        get_selection_input=MagicMock(return_value="1"),
+        get_confirm=MagicMock(return_value=True),
+        settings=MagicMock(),
+    )
+    mocks.settings.return_value.get.return_value = 80
+
+    monkeypatch.setattr(f"{MODULE}.get_distro_info", mocks.get_distro_info)
+    monkeypatch.setattr(f"{MODULE}.get_existing_clients", mocks.get_existing_clients)
+    monkeypatch.setattr(f"{MODULE}.get_nginx_config_list", mocks.get_nginx_config_list)
+    monkeypatch.setattr(f"{MODULE}.ensure_certbot", mocks.ensure_certbot)
+    monkeypatch.setattr(f"{MODULE}.write_credentials", mocks.write_credentials)
+    monkeypatch.setattr(f"{MODULE}.remove_credentials", mocks.remove_credentials)
+    monkeypatch.setattr(f"{MODULE}.credentials_exist", mocks.credentials_exist)
+    monkeypatch.setattr(
+        f"{MODULE}.credentials_match_provider", mocks.credentials_match_provider
+    )
+    monkeypatch.setattr(f"{MODULE}.backup_credentials", mocks.backup_credentials)
+    monkeypatch.setattr(f"{MODULE}.restore_credentials", mocks.restore_credentials)
+    monkeypatch.setattr(
+        f"{MODULE}.discard_credentials_backup", mocks.discard_credentials_backup
+    )
+    monkeypatch.setattr(f"{MODULE}.run_certbot", mocks.run_certbot)
+    monkeypatch.setattr(f"{MODULE}.install_renew_hook", mocks.install_renew_hook)
+    monkeypatch.setattr(f"{MODULE}.cert_paths", mocks.cert_paths)
+    monkeypatch.setattr(f"{MODULE}.backup_site", mocks.backup_site)
+    monkeypatch.setattr(f"{MODULE}.write_site", mocks.write_site)
+    monkeypatch.setattr(f"{MODULE}.restore_site", mocks.restore_site)
+    monkeypatch.setattr(f"{MODULE}.discard_backup", mocks.discard_backup)
+    monkeypatch.setattr(f"{MODULE}.nginx_config_test", mocks.nginx_config_test)
+    monkeypatch.setattr(f"{MODULE}.reload_nginx", mocks.reload_nginx)
+    monkeypatch.setattr(f"{MODULE}.get_string_input", mocks.get_string_input)
+    monkeypatch.setattr(f"{MODULE}.get_secret_input", mocks.get_secret_input)
+    monkeypatch.setattr(f"{MODULE}.get_selection_input", mocks.get_selection_input)
+    monkeypatch.setattr(f"{MODULE}.get_confirm", mocks.get_confirm)
+    monkeypatch.setattr(f"{MODULE}.KiauhSettings", mocks.settings)
+    return mocks
+
+
+def _https_fixture(http_config_text: str) -> str:
+    result: str = build_https_config(http_config_text, FQDN, FULLCHAIN, PRIVKEY)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# install_extension
+# --------------------------------------------------------------------------- #
+def test_install_happy_path_writes_https_config(env):
+    HttpsExtension({}).install_extension()
+
+    written = env.site.read_text()
+    assert config_enables_https(written)
+    assert f"return 301 https://{FQDN}$request_uri;" in written
+    assert f"ssl_certificate {FULLCHAIN};" in written
+    env.run_certbot.assert_called_once()
+    env.install_renew_hook.assert_called_once()
+    env.reload_nginx.assert_called_once()
+    # the backup is cleaned up once the new config is live
+    env.discard_backup.assert_called_once()
+    assert not Path(str(env.site) + ".kiauh.bak").exists()
+
+
+def test_install_aborts_on_malformed_site_before_issuing_cert(env):
+    # a site with no parseable server block must fail BEFORE certbot runs
+    env.site.write_text("this is not a valid nginx site\n")
+    HttpsExtension({}).install_extension()
+
+    env.ensure_certbot.assert_not_called()
+    env.run_certbot.assert_not_called()
+    env.backup_site.assert_not_called()
+    assert env.site.read_text() == "this is not a valid nginx site\n"
+
+
+def test_install_aborts_when_no_client(env, http_config_text):
+    env.get_existing_clients.return_value = []
+    HttpsExtension({}).install_extension()
+
+    env.run_certbot.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_aborts_on_unsupported_distro(env, http_config_text):
+    env.get_distro_info.return_value = ("arch", "")
+    HttpsExtension({}).install_extension()
+
+    env.get_existing_clients.assert_not_called()
+    env.run_certbot.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_skips_when_already_https(env, http_config_text):
+    env.site.write_text(_https_fixture(http_config_text))
+    HttpsExtension({}).install_extension()
+
+    env.run_certbot.assert_not_called()
+
+
+def test_install_lowercases_the_fqdn(env):
+    # certbot canonicalizes to lowercase; an uppercase FQDN would otherwise
+    # yield a cert path that does not exist and fail nginx -t after issuance
+    env.get_string_input.side_effect = ["Printer.Example.COM", "me@example.com"]
+    HttpsExtension({}).install_extension()
+
+    written = env.site.read_text()
+    assert "printer.example.com" in written
+    assert "Printer.Example.COM" not in written
+
+
+def test_install_aborts_when_site_not_enabled(env, http_config_text):
+    # the sites-enabled symlink was removed; rewriting the unloaded site would
+    # falsely report success, so installation must abort before issuing a cert
+    env.sites_enabled.joinpath("mainsail").unlink()
+    HttpsExtension({}).install_extension()
+
+    env.run_certbot.assert_not_called()
+    env.backup_site.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_aborts_on_443_conflict(env, http_config_text, tmp_path):
+    # another enabled site already listens on 443, even though it is not the
+    # last listen in its file - the scan must still see it
+    other = tmp_path.joinpath("other")
+    other.write_text("server {\n    listen 443 ssl;\n    listen 9000;\n}\n")
+    env.get_nginx_config_list.return_value = [other]
+    HttpsExtension({}).install_extension()
+
+    env.run_certbot.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_reuses_existing_credentials_on_reenable(env):
+    # re-enabling a cert kept from a previous enable must reuse the working
+    # credentials (not prompt for or overwrite them) and run certbot against the
+    # existing file - overwriting could break renewal of the still-valid cert
+    env.credentials_exist.return_value = True
+
+    HttpsExtension({}).install_extension()
+
+    env.get_secret_input.assert_not_called()  # no token prompt on re-enable
+    env.write_credentials.assert_not_called()  # the working file is left as-is
+    env.run_certbot.assert_called_once()
+    assert env.run_certbot.call_args.args[4] == credentials_file(FQDN)
+
+
+def test_install_replaces_credentials_when_user_declines_reuse(env):
+    # if the saved token was rotated or the provider changed, declining reuse
+    # must prompt for and write fresh credentials (not a dead end)
+    env.credentials_exist.return_value = True
+    env.get_confirm.side_effect = [False, True]  # don't reuse, then continue
+
+    HttpsExtension({}).install_extension()
+
+    env.get_secret_input.assert_called()  # prompted for a new token
+    env.write_credentials.assert_called_once()  # fresh credentials written
+    env.run_certbot.assert_called_once()
+
+
+def test_install_does_not_offer_reuse_for_mismatched_provider(env):
+    # saved credentials belong to a different DNS provider; reuse must not be
+    # offered and the user is prompted for credentials for the new provider
+    env.credentials_exist.return_value = True
+    env.credentials_match_provider.return_value = False
+
+    HttpsExtension({}).install_extension()
+
+    env.get_secret_input.assert_called()  # prompted for new credentials
+    env.write_credentials.assert_called_once()
+    # the reuse question is never asked - only the final "Continue?"
+    assert env.get_confirm.call_count == 1
+
+
+def test_install_forces_renewal_when_replacing_credentials(env):
+    # replacing credentials must force a real renewal so the new token is
+    # validated, not silently kept by --keep-until-expiring
+    env.credentials_exist.return_value = True
+    env.get_confirm.side_effect = [False, True]  # don't reuse (replace), continue
+
+    HttpsExtension({}).install_extension()
+
+    assert env.run_certbot.call_args.kwargs.get("force_renewal") is True
+
+
+def test_install_aborts_when_backup_fails_on_replace(env, http_config_text):
+    # if the working credentials cannot be backed up, abort rather than
+    # overwrite an unrecoverable file
+    env.credentials_exist.return_value = True
+    env.get_confirm.side_effect = [False, True]  # replace
+    env.backup_credentials.side_effect = CalledProcessError(1, "cp")
+
+    HttpsExtension({}).install_extension()
+
+    env.write_credentials.assert_not_called()
+    env.run_certbot.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_replace_failure_restores_existing_credentials(env):
+    # declining reuse to replace credentials, then a failed issuance, must
+    # restore the previous working file - the retained cert renews with it
+    backup = Path("/root/.secrets/printer.example.com.ini.bak")
+    env.credentials_exist.return_value = True
+    env.backup_credentials.return_value = backup
+    env.get_confirm.side_effect = [False, True]  # don't reuse, then continue
+    env.run_certbot.side_effect = CalledProcessError(1, "certbot")
+
+    HttpsExtension({}).install_extension()  # must not raise
+
+    env.restore_credentials.assert_called_once_with(backup, FQDN)
+    env.remove_credentials.assert_not_called()
+
+
+def test_install_reenable_failure_does_not_touch_existing_credentials(env):
+    # a failed re-enable must NOT remove the existing credentials - they belong
+    # to a certificate that is still renewing
+    env.credentials_exist.return_value = True
+    env.run_certbot.side_effect = CalledProcessError(1, "certbot")
+
+    HttpsExtension({}).install_extension()  # must not raise
+
+    env.remove_credentials.assert_not_called()
+    env.write_credentials.assert_not_called()
+
+
+def test_install_leaves_nginx_untouched_when_cert_fails(env, http_config_text):
+    env.run_certbot.side_effect = CalledProcessError(1, "certbot")
+    HttpsExtension({}).install_extension()
+
+    env.backup_site.assert_not_called()
+    env.write_site.assert_not_called()
+    env.reload_nginx.assert_not_called()
+    # the token file written before issuance is cleaned up on the aborted path,
+    # via the FQDN's deterministic path (covers a partial write that never
+    # returned a path)
+    env.remove_credentials.assert_called_once_with(credentials_file(FQDN))
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_survives_credentials_write_failure(env, http_config_text):
+    # the first sudo after confirmation (writing the token) can fail on an
+    # expired/declined sudo password; the menu must not crash and nginx and
+    # certbot must be left untouched
+    env.write_credentials.side_effect = CalledProcessError(1, "tee")
+    HttpsExtension({}).install_extension()
+
+    env.run_certbot.assert_not_called()
+    env.install_renew_hook.assert_not_called()
+    env.backup_site.assert_not_called()
+    env.write_site.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_keeps_going_when_renew_hook_fails(env):
+    # the cert is issued but the (non-fatal) renewal hook fails; the credentials
+    # the issued cert renews with must be kept and HTTPS still applied
+    env.install_renew_hook.side_effect = CalledProcessError(1, "tee")
+    HttpsExtension({}).install_extension()
+
+    env.run_certbot.assert_called_once()
+    env.remove_credentials.assert_not_called()  # the issued cert references them
+    env.write_site.assert_called_once()  # HTTPS is still applied
+    assert config_enables_https(env.site.read_text())
+
+
+def test_install_aborts_cleanly_when_certbot_install_fails(env, http_config_text):
+    env.ensure_certbot.side_effect = CalledProcessError(1, "apt-get")
+    HttpsExtension({}).install_extension()
+
+    # apt failure must not crash the menu, write credentials or touch nginx
+    env.write_credentials.assert_not_called()
+    env.run_certbot.assert_not_called()
+    env.backup_site.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_redirect_block_keeps_current_http_port(env, http_config_text):
+    custom = http_config_text.replace("listen 80;", "listen 8080;").replace(
+        "listen [::]:80;", "listen [::]:8080;"
+    )
+    env.site.write_text(custom)
+    HttpsExtension({}).install_extension()
+
+    redirect_block = env.site.read_text().split("listen 443 ssl")[0]
+    assert "listen 8080;" in redirect_block
+    assert "listen 80;" not in redirect_block
+
+
+def test_install_rolls_back_when_nginx_test_fails(env, http_config_text):
+    env.nginx_config_test.return_value = False
+    HttpsExtension({}).install_extension()
+
+    env.restore_site.assert_called_once()
+    # the site is back to the original plain-HTTP config
+    assert env.site.read_text() == http_config_text
+    assert not config_enables_https(env.site.read_text())
+    # the backup is discarded even on the rollback path
+    env.discard_backup.assert_called_once()
+    assert not Path(str(env.site) + ".kiauh.bak").exists()
+
+
+def test_install_aborts_when_listen_port_unknown(env, http_config_text, monkeypatch):
+    # an unreadable listen port means a non-standard site; guessing port 80
+    # would break the HTTP<->HTTPS round-trip, so installation must abort
+    monkeypatch.setattr(f"{MODULE}.get_nginx_listen_port", MagicMock(return_value=None))
+    HttpsExtension({}).install_extension()
+
+    env.ensure_certbot.assert_not_called()
+    env.run_certbot.assert_not_called()
+    env.write_site.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_reverts_when_a_privileged_step_raises(env, http_config_text):
+    # reload after writing the new config fails; install must restore the
+    # original site and never propagate the CalledProcessError
+    env.reload_nginx.side_effect = CalledProcessError(1, "systemctl reload nginx")
+    HttpsExtension({}).install_extension()
+
+    assert env.site.read_text() == http_config_text
+    env.restore_site.assert_called()
+    assert not Path(str(env.site) + ".kiauh.bak").exists()
+
+
+def test_install_survives_backup_failure(env, http_config_text):
+    # even the first privileged step (backup) can fail; install must surface a
+    # clean error and leave the original site untouched
+    env.backup_site.side_effect = CalledProcessError(1, "cp")
+    HttpsExtension({}).install_extension()
+
+    assert env.site.read_text() == http_config_text
+    env.write_site.assert_not_called()
+
+
+def test_install_keeps_https_when_backup_cleanup_fails(env):
+    # dropping the backup after a successful reload is best-effort cleanup; its
+    # failure must NOT roll back the HTTPS config that is already live
+    env.discard_backup.side_effect = CalledProcessError(1, "rm")
+    HttpsExtension({}).install_extension()
+
+    assert config_enables_https(env.site.read_text())
+    env.restore_site.assert_not_called()
+
+
+def test_install_keeps_backup_when_restore_fails(env):
+    # the new config fails nginx -t AND restoring the backup also fails; the
+    # backup must be kept (not discarded) so manual recovery is still possible
+    env.nginx_config_test.return_value = False
+    env.restore_site.side_effect = CalledProcessError(1, "cp")
+
+    HttpsExtension({}).install_extension()  # must not raise
+
+    env.discard_backup.assert_not_called()
+    assert Path(str(env.site) + ".kiauh.bak").exists()
+
+
+def test_install_does_not_restore_stale_backup_on_backup_failure(env, http_config_text):
+    # a stale .bak from a previous failed run must NOT be restored when the
+    # current backup step fails before creating its own
+    stale = Path(str(env.site) + ".kiauh.bak")
+    stale.write_text("STALE OLD CONFIG\n")
+    env.backup_site.side_effect = CalledProcessError(1, "cp")
+
+    HttpsExtension({}).install_extension()
+
+    # the live site is untouched - not overwritten with the stale backup
+    assert env.site.read_text() == http_config_text
+    env.restore_site.assert_not_called()
+    env.write_site.assert_not_called()
+
+
+def test_install_survives_credentials_cleanup_failure(env, http_config_text):
+    # issuance fails AND the token cleanup itself fails; the menu must still
+    # surface its error rather than crash on the secondary CalledProcessError
+    env.run_certbot.side_effect = CalledProcessError(1, "certbot")
+    env.remove_credentials.side_effect = CalledProcessError(1, "rm")
+
+    HttpsExtension({}).install_extension()  # must not raise
+
+    env.backup_site.assert_not_called()
+    assert env.site.read_text() == http_config_text
+
+
+def test_install_token_uses_no_echo_prompt(env):
+    HttpsExtension({}).install_extension()
+    env.get_secret_input.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# remove_extension
+# --------------------------------------------------------------------------- #
+def test_remove_reverse_transforms_to_plain_http(env, http_config_text):
+    env.site.write_text(_https_fixture(http_config_text))
+    HttpsExtension({}).remove_extension()
+
+    written = env.site.read_text()
+    # back to plain HTTP, not a stock-template reset: the user body survives
+    assert not config_enables_https(written)
+    assert "listen 80;" in written
+    assert "ssl_certificate" not in written
+    assert "return 301" not in written  # the :80 redirect block is dropped
+    # body carried over verbatim (custom locations, proxies, directives)
+    assert "proxy_pass http://apiserver/websocket;" in written
+    assert "proxy_pass http://mjpgstreamer4/;" in written
+    assert "client_max_body_size 0;" in written
+    env.reload_nginx.assert_called_once()
+
+
+def test_remove_restores_port_from_live_site_not_settings(env, http_config_text):
+    # the site was on 8080 before HTTPS; KIAUH settings (mock) report 80.
+    # the restore must use the live site's recorded port, not settings.
+    https = build_https_config(
+        http_config_text, FQDN, FULLCHAIN, PRIVKEY, redirect_port=8080
+    )
+    env.site.write_text(https)
+    env.settings.return_value.get.return_value = 80
+
+    HttpsExtension({}).remove_extension()
+
+    assert "listen 8080;" in env.site.read_text()
+
+
+def test_remove_falls_back_to_settings_port_when_redirect_is_443(env):
+    # a site whose first block is the TLS block (e.g. configured outside this
+    # extension): extract_redirect_port would read 443, so the restore must
+    # fall back to the configured HTTP port instead of rebuilding HTTP on 443
+    manual = (
+        "server {\n"
+        "    listen 443 ssl;\n"
+        "    server_name printer.example.com _;\n"
+        "    root /home/pi/mainsail;\n"
+        "}\n"
+    )
+    env.site.write_text(manual)
+    env.settings.return_value.get.return_value = 80
+
+    HttpsExtension({}).remove_extension()
+
+    written = env.site.read_text()
+    assert "listen 80;" in written
+    assert "listen 443" not in written
+    assert not config_enables_https(written)
+
+
+def test_remove_informs_when_not_https(env):
+    HttpsExtension({}).remove_extension()
+    env.backup_site.assert_not_called()
+    env.write_site.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# distro gate
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("distro_id", "supported"),
+    [
+        ("debian", True),
+        ("ubuntu", True),
+        ("raspbian", True),
+        ("armbian", True),
+        ("linuxmint", True),
+        ("arch", False),
+        ("fedora", False),
+        ("", False),
+    ],
+)
+def test_distro_gate(monkeypatch, distro_id, supported):
+    monkeypatch.setattr(f"{MODULE}.get_distro_info", lambda: (distro_id, "1"))
+    assert HttpsExtension({})._distro_supported() is supported
+
+
+def test_distro_gate_handles_value_error(monkeypatch):
+    def boom():
+        raise ValueError("no os-release")
+
+    monkeypatch.setattr(f"{MODULE}.get_distro_info", boom)
+    assert HttpsExtension({})._distro_supported() is False
+
+
+# --------------------------------------------------------------------------- #
+# credential prompting
+# --------------------------------------------------------------------------- #
+def test_prompt_credentials_allows_special_chars_and_defaults(monkeypatch):
+    provider = DnsProvider(
+        key="custom",
+        display_name="Custom",
+        plugin_package="python3-certbot-dns-custom",
+        plugin_flag="--dns-custom",
+        credentials_fields=[
+            CredField(ini_key="token", prompt="Token", secret=True),
+            CredField(ini_key="zone", prompt="Zone", secret=False),
+            CredField(ini_key="version", prompt="Version", secret=False, default="4"),
+        ],
+    )
+    string_input = MagicMock(side_effect=["my-zone_id.example/v1", "4"])
+    monkeypatch.setattr(f"{MODULE}.get_secret_input", MagicMock(return_value="tok"))
+    monkeypatch.setattr(f"{MODULE}.get_string_input", string_input)
+
+    values = HttpsExtension({})._prompt_credentials(provider)
+
+    assert values == {"token": "tok", "zone": "my-zone_id.example/v1", "version": "4"}
+    # plain fields must accept '-', '_', '.', '/' and offer the field default
+    for call in string_input.call_args_list:
+        assert call.kwargs.get("allow_special_chars") is True
+    assert string_input.call_args_list[1].kwargs.get("default") == "4"
+
+
+def test_distro_gate_handles_called_process_error(monkeypatch):
+    def boom():
+        # get_distro_info runs `cat /etc/os-release`; a missing file makes the
+        # subprocess exit non-zero -> CalledProcessError (not an OSError)
+        raise CalledProcessError(1, ["cat", "/etc/os-release"])
+
+    monkeypatch.setattr(f"{MODULE}.get_distro_info", boom)
+    assert HttpsExtension({})._distro_supported() is False

--- a/kiauh/extensions/https/tests/test_nginx_https.py
+++ b/kiauh/extensions/https/tests/test_nginx_https.py
@@ -1,0 +1,272 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+import pytest
+from extensions.https.nginx_https import (
+    AlreadyHttpsError,
+    build_http_config,
+    build_https_config,
+    extract_fqdn,
+    extract_redirect_port,
+    extract_server_body,
+    extract_tls_server_body,
+    strip_listen_directives,
+)
+from utils.nginx_utils import config_enables_https
+
+FQDN = "printer.example.com"
+CERT = f"/etc/letsencrypt/live/{FQDN}/fullchain.pem"
+KEY = f"/etc/letsencrypt/live/{FQDN}/privkey.pem"
+
+
+# --------------------------------------------------------------------------- #
+# extract_server_body
+# --------------------------------------------------------------------------- #
+def test_extract_server_body_returns_inner_body(http_config_text):
+    body = extract_server_body(http_config_text)
+    # the inner body keeps the location blocks ...
+    assert "location /websocket" in body
+    assert "proxy_pass http://mjpgstreamer4/;" in body
+    # ... but not the outermost `server {` wrapper
+    assert "server {" not in body
+
+
+def test_extract_server_body_balances_nested_braces():
+    cfg = (
+        "server {\n"
+        "    location / {\n"
+        "        try_files $uri =404;\n"
+        "    }\n"
+        "    location /a {\n"
+        "        nested {\n"
+        "            deep {\n"
+        "            }\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+    body = extract_server_body(cfg)
+    assert "location /a" in body
+    assert "deep {" in body
+    # every brace in the extracted body is balanced
+    assert body.count("{") == body.count("}")
+    # the server's own closing brace is excluded
+    assert not body.rstrip().endswith("}\n}")
+
+
+def test_extract_server_body_raises_on_unbalanced():
+    with pytest.raises(ValueError):
+        extract_server_body("server {\n    location / {\n")
+
+
+def test_extract_server_body_raises_when_no_server_block():
+    with pytest.raises(ValueError):
+        extract_server_body("# just a comment, no server block\n")
+
+
+def test_extract_server_body_ignores_commented_server_keyword():
+    # a comment mentioning "server {" before the real block must not be matched
+    cfg = "# was: server { dead block }\nserver {\n    listen 80;\n}\n"
+    body = extract_server_body(cfg)
+    assert "listen 80;" in body
+    assert "dead block" not in body
+
+
+def test_build_https_config_survives_leading_comment_with_brace(http_config_text):
+    # a leading comment containing braces must not derail block extraction
+    cfg = "# example server { ... } block\n" + http_config_text
+    result = build_https_config(cfg, FQDN, CERT, KEY)
+    assert config_enables_https(result)
+    assert "proxy_pass http://apiserver/websocket;" in result
+
+
+# --------------------------------------------------------------------------- #
+# strip_listen_directives
+# --------------------------------------------------------------------------- #
+def test_strip_listen_directives_removes_listen_lines(http_config_text):
+    body = strip_listen_directives(extract_server_body(http_config_text))
+    for line in body.splitlines():
+        assert not line.strip().startswith("listen")
+        assert not line.strip().startswith("# listen")
+    # bare catch-all server_name is dropped so the TLS block sets its own
+    assert "server_name _;" not in body
+    # the meaningful body survives
+    assert "root /home/pi/mainsail;" in body
+    assert "location /websocket" in body
+
+
+# --------------------------------------------------------------------------- #
+# build_https_config
+# --------------------------------------------------------------------------- #
+def test_build_https_config_has_redirect_block(http_config_text):
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    redirect_block = result.split("listen 443 ssl")[0]
+    assert "listen 80;" in redirect_block
+    assert "# listen [::]:80;" in redirect_block
+    assert "    listen [::]:80;" not in redirect_block
+    assert f"return 301 https://{FQDN}$request_uri;" in redirect_block
+    # a pure redirect server must carry no proxy/location logic
+    assert "location" not in redirect_block
+
+
+def test_build_https_config_has_tls_block(http_config_text):
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert "listen 443 ssl http2;" in result
+    assert f"ssl_certificate {CERT};" in result
+    assert f"ssl_certificate_key {KEY};" in result
+    assert "ssl_protocols TLSv1.2 TLSv1.3;" in result
+    assert f"server_name {FQDN} _;" in result
+
+
+def test_build_https_config_preserves_original_body(http_config_text):
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert "proxy_pass http://apiserver/websocket;" in result
+    for n in ("", "2", "3", "4"):
+        assert f"proxy_pass http://mjpgstreamer{n or '1'}/;" in result
+    assert "proxy_pass http://apiserver$request_uri;" in result
+
+
+def test_build_https_config_total_redirect(http_config_text):
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    # exactly one redirect, and it lives in the port-80 block
+    assert result.count("return 301") == 1
+    assert "return 301" in result.split("listen 443 ssl")[0]
+
+
+def test_build_https_config_redirect_target_is_fqdn_not_host(http_config_text):
+    # the redirect must target the validated FQDN, never $host: the block
+    # answers the catch-all server_name, so $host would be an open redirect
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert f"return 301 https://{FQDN}$request_uri;" in result
+    assert "$host" not in result
+
+
+def test_build_https_config_custom_redirect_port(http_config_text):
+    result = build_https_config(http_config_text, FQDN, CERT, KEY, redirect_port=8080)
+    redirect_block = result.split("listen 443 ssl")[0]
+    assert "listen 8080;" in redirect_block
+    assert "# listen [::]:8080;" in redirect_block
+    assert "    listen [::]:8080;" not in redirect_block
+
+
+def test_build_https_config_comments_out_ipv6_listen(http_config_text):
+    # an active 'listen [::]' fails nginx -t on IPv6-disabled hosts; KIAUH ships
+    # the IPv6 listen commented, so both generated blocks must follow suit
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert "# listen [::]:80;" in result
+    assert "# listen [::]:443 ssl http2;" in result
+    # no ACTIVE (uncommented) IPv6 listen in either block
+    assert "    listen [::]:80;" not in result
+    assert "    listen [::]:443" not in result
+
+
+def test_build_https_config_raises_on_already_https(http_config_text):
+    once = build_https_config(http_config_text, FQDN, CERT, KEY)
+    with pytest.raises(AlreadyHttpsError):
+        build_https_config(once, FQDN, CERT, KEY)
+
+
+def test_build_https_config_matches_golden(http_config_text, expected_https_text):
+    result = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert result == expected_https_text
+
+
+# --------------------------------------------------------------------------- #
+# extract_fqdn
+# --------------------------------------------------------------------------- #
+def test_extract_fqdn_from_https_config(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert extract_fqdn(https) == FQDN
+
+
+def test_extract_fqdn_none_for_plain_http(http_config_text):
+    # the generated HTTP site only has the catch-all `server_name _;`
+    assert extract_fqdn(http_config_text) is None
+
+
+# --------------------------------------------------------------------------- #
+# build output is recognised as HTTPS (cross-check with the shared detector)
+# --------------------------------------------------------------------------- #
+def test_plain_http_is_not_detected_as_https(http_config_text):
+    assert config_enables_https(http_config_text) is False
+
+
+def test_build_output_is_detected_as_https(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert config_enables_https(https) is True
+
+
+# --------------------------------------------------------------------------- #
+# extract_redirect_port
+# --------------------------------------------------------------------------- #
+def test_extract_redirect_port_default_80(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY)
+    assert extract_redirect_port(https) == 80
+
+
+def test_extract_redirect_port_custom(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY, redirect_port=8080)
+    assert extract_redirect_port(https) == 8080
+
+
+def test_extract_redirect_port_none_when_absent():
+    assert extract_redirect_port("# no server block here\n") is None
+
+
+# --------------------------------------------------------------------------- #
+# extract_tls_server_body / build_http_config (reverse transform)
+# --------------------------------------------------------------------------- #
+def test_extract_tls_server_body_picks_tls_block(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY)
+    body = extract_tls_server_body(https)
+    assert "listen 443 ssl http2;" in body
+    assert "return 301" not in body  # not the redirect block
+
+
+def test_extract_tls_server_body_raises_for_plain_http(http_config_text):
+    with pytest.raises(ValueError):
+        extract_tls_server_body(http_config_text)
+
+
+def test_build_http_config_reverses_to_plain_http(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY)
+    http = build_http_config(https, port=80)
+    assert config_enables_https(http) is False
+    assert "listen 80;" in http
+    assert "# listen [::]:80;" in http
+    assert "ssl_certificate" not in http
+    assert "ssl_protocols" not in http
+    assert "listen 443" not in http
+    assert f"server_name {FQDN} _;" not in http
+    assert "return 301" not in http  # the redirect block is discarded
+    # the body (root, proxy/location blocks) is preserved verbatim
+    assert "proxy_pass http://apiserver/websocket;" in http
+    for n in ("", "2", "3", "4"):
+        assert f"proxy_pass http://mjpgstreamer{n or '1'}/;" in http
+    assert "client_max_body_size 0;" in http
+
+
+def test_build_http_config_restores_custom_port(http_config_text):
+    https = build_https_config(http_config_text, FQDN, CERT, KEY, redirect_port=8080)
+    http = build_http_config(https, port=8080)
+    assert "listen 8080;" in http
+    assert "# listen [::]:8080;" in http
+
+
+def test_build_http_config_round_trip_allows_reenabling(http_config_text):
+    # http -> https -> http -> https must keep working and preserve the body
+    https = build_https_config(http_config_text, FQDN, CERT, KEY)
+    http = build_http_config(https, port=80)
+    again = build_https_config(http, FQDN, CERT, KEY)
+    assert config_enables_https(again) is True
+    assert "proxy_pass http://mjpgstreamer4/;" in again
+
+
+def test_build_http_config_raises_without_tls_block(http_config_text):
+    with pytest.raises(ValueError):
+        build_http_config(http_config_text, port=80)

--- a/kiauh/extensions/https/tests/test_nginx_ops.py
+++ b/kiauh/extensions/https/tests/test_nginx_ops.py
@@ -1,0 +1,69 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from extensions.https.nginx_ops import (
+    backup_site,
+    discard_backup,
+    nginx_config_test,
+    reload_nginx,
+    restore_site,
+    write_site,
+)
+
+SITE = Path("/etc/nginx/sites-available/mainsail")
+BACKUP = Path("/etc/nginx/sites-available/mainsail.kiauh.bak")
+
+
+def test_backup_site_copies_with_sudo():
+    with patch("extensions.https.nginx_ops.run") as run:
+        backup = backup_site(SITE)
+    assert backup == BACKUP
+    assert run.call_args.args[0] == ["sudo", "cp", str(SITE), str(BACKUP)]
+
+
+def test_write_site_passes_content_via_tee_stdin():
+    with patch("extensions.https.nginx_ops.run") as run:
+        write_site(SITE, "server {}\n")
+    assert run.call_args.args[0] == ["sudo", "tee", str(SITE)]
+    assert run.call_args.kwargs["input"] == b"server {}\n"
+
+
+def test_restore_site_copies_backup_back():
+    with patch("extensions.https.nginx_ops.run") as run:
+        restore_site(BACKUP, SITE)
+    assert run.call_args.args[0] == ["sudo", "cp", str(BACKUP), str(SITE)]
+
+
+def test_discard_backup_removes_with_sudo():
+    with patch("extensions.https.nginx_ops.run") as run:
+        discard_backup(BACKUP)
+    assert run.call_args.args[0] == ["sudo", "rm", "-f", str(BACKUP)]
+
+
+def test_nginx_config_test_returns_true_on_zero_exit():
+    result = MagicMock(returncode=0, stderr=b"")
+    with patch("extensions.https.nginx_ops.run", return_value=result):
+        assert nginx_config_test() is True
+
+
+def test_nginx_config_test_returns_false_and_logs_error_on_nonzero_exit():
+    result = MagicMock(returncode=1, stderr=b"nginx: [emerg] cert not found")
+    with patch("extensions.https.nginx_ops.run", return_value=result):
+        with patch("extensions.https.nginx_ops.Logger") as logger:
+            assert nginx_config_test() is False
+    logged = " ".join(str(c) for c in logger.print_error.call_args_list)
+    assert "cert not found" in logged
+
+
+def test_reload_nginx_uses_systemctl_reload():
+    with patch("extensions.https.nginx_ops.cmd_sysctl_service") as svc:
+        reload_nginx()
+    svc.assert_called_once_with("nginx", "reload")

--- a/kiauh/extensions/https/tests/test_providers.py
+++ b/kiauh/extensions/https/tests/test_providers.py
@@ -1,0 +1,144 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+import pytest
+from extensions.https.providers import (
+    PROVIDERS,
+    CredField,
+    DnsProvider,
+    build_certbot_command,
+    build_credentials_content,
+)
+
+SHORT_FLAGS = {"-d", "-m", "-n"}
+
+
+def test_ships_expected_providers():
+    assert set(PROVIDERS) >= {"cloudflare", "digitalocean", "linode"}
+
+
+@pytest.mark.parametrize("key", list(PROVIDERS))
+def test_every_provider_is_wellformed(key):
+    provider = PROVIDERS[key]
+    assert provider.key == key
+    assert provider.display_name
+    assert provider.plugin_package.startswith("python3-certbot-dns-")
+    assert provider.plugin_flag.startswith("--dns-")
+    assert provider.credentials_fields
+    assert provider.default_propagation > 0
+
+
+def test_build_certbot_command_cloudflare():
+    cmd = build_certbot_command(
+        PROVIDERS["cloudflare"],
+        fqdn="printer.example.com",
+        email="me@example.com",
+        propagation_seconds=30,
+        credentials_path="/root/.secrets/cloudflare.ini",
+    )
+    assert cmd[:3] == ["sudo", "certbot", "certonly"]
+    assert "--dns-cloudflare" in cmd
+    assert "--dns-cloudflare-credentials" in cmd
+    assert "/root/.secrets/cloudflare.ini" in cmd
+    assert "--dns-cloudflare-propagation-seconds" in cmd
+    assert "30" in cmd
+    assert cmd[cmd.index("--domain") + 1] == "printer.example.com"
+    assert cmd[cmd.index("--email") + 1] == "me@example.com"
+    assert "--non-interactive" in cmd
+    assert "--agree-tos" in cmd
+    assert "--keep-until-expiring" in cmd
+
+
+@pytest.mark.parametrize("key", list(PROVIDERS))
+def test_build_certbot_command_opts_out_of_eff_email(key):
+    # running non-interactively, certbot must not be left to decide on the EFF
+    # mailing-list subscription; --no-eff-email makes the opt-out explicit
+    cmd = build_certbot_command(
+        PROVIDERS[key], "p.example.com", "me@example.com", 30, "/x/creds.ini"
+    )
+    assert "--no-eff-email" in cmd
+
+
+def test_build_certbot_command_keeps_cert_by_default():
+    cmd = build_certbot_command(
+        PROVIDERS["cloudflare"], "p.example.com", "me@example.com", 30, "/x/cf.ini"
+    )
+    assert "--keep-until-expiring" in cmd
+    assert "--force-renewal" not in cmd
+
+
+def test_build_certbot_command_force_renewal_swaps_keep_flag():
+    # replacing credentials must validate the new token via a real renewal
+    cmd = build_certbot_command(
+        PROVIDERS["cloudflare"],
+        "p.example.com",
+        "me@example.com",
+        30,
+        "/x/cf.ini",
+        force_renewal=True,
+    )
+    assert "--force-renewal" in cmd
+    assert "--keep-until-expiring" not in cmd
+
+
+def test_build_certbot_command_uses_only_long_flags():
+    cmd = build_certbot_command(
+        PROVIDERS["linode"], "p.example.com", "me@example.com", 120, "/x/linode.ini"
+    )
+    assert SHORT_FLAGS.isdisjoint(cmd)
+
+
+def test_build_certbot_command_omits_optional_flags_when_provider_has_none():
+    # a future env/IAM provider with no credentials/propagation flags must
+    # still produce a valid command
+    provider = DnsProvider(
+        key="envprov",
+        display_name="EnvProvider",
+        plugin_package="python3-certbot-dns-envprov",
+        plugin_flag="--dns-envprov",
+        credentials_fields=[CredField(ini_key="x", prompt="x")],
+        credentials_flag=None,
+        propagation_flag=None,
+        credentials_filename=None,
+    )
+    cmd = build_certbot_command(provider, "p.example.com", "me@example.com", 30, None)
+    assert "--dns-envprov" in cmd
+    assert not any(c.endswith("-credentials") for c in cmd)
+    assert not any(c.endswith("-propagation-seconds") for c in cmd)
+    assert "--domain" in cmd
+
+
+def test_build_certbot_command_never_contains_a_secret_value():
+    # the token lives only in the credentials file; the argv references the
+    # file path, never the secret itself
+    cmd = build_certbot_command(
+        PROVIDERS["cloudflare"], "p.example.com", "me@example.com", 30, "/x/cf.ini"
+    )
+    assert "supersecrettoken" not in " ".join(cmd)
+
+
+def test_build_credentials_content_single_field():
+    body = build_credentials_content(
+        PROVIDERS["cloudflare"], {"dns_cloudflare_api_token": "supersecrettoken"}
+    )
+    assert body == "dns_cloudflare_api_token = supersecrettoken\n"
+
+
+def test_build_credentials_content_multi_field_linode():
+    body = build_credentials_content(
+        PROVIDERS["linode"],
+        {"dns_linode_key": "abc123", "dns_linode_version": "4"},
+    )
+    assert body == "dns_linode_key = abc123\ndns_linode_version = 4\n"
+
+
+def test_build_credentials_content_trims_whitespace():
+    body = build_credentials_content(
+        PROVIDERS["cloudflare"], {"dns_cloudflare_api_token": "  padded-token  "}
+    )
+    assert body == "dns_cloudflare_api_token = padded-token\n"

--- a/kiauh/utils/input_utils.py
+++ b/kiauh/utils/input_utils.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import re
+from getpass import getpass
 from typing import Dict, List
 
 from core.constants import INVALID_CHOICE
@@ -120,6 +121,26 @@ def get_string_input(
             return _input
         else:
             Logger.print_error(INVALID_CHOICE)
+
+
+def get_secret_input(question: str, allow_empty: bool = False) -> str:
+    """
+    Helper method to get a secret (e.g. an API token) from the user WITHOUT
+    echoing it to the terminal. Unlike get_string_input, this never displays
+    the value or leaves it in the terminal scrollback, so it is safe for
+    credentials. The value is returned verbatim (not stripped) so secrets are
+    never silently mutated; only blank input is rejected.
+    :param question: The question to display
+    :param allow_empty: Whether to allow empty input
+    :return: The entered secret
+    """
+    _question = format_question(question, None)
+    while True:
+        value = getpass(_question)
+        if value.strip() == "" and not allow_empty:
+            Logger.print_error("Input must not be empty!")
+            continue
+        return value
 
 
 def get_selection_input(question: str, option_list: List | Dict, default=None) -> str:

--- a/kiauh/utils/nginx_utils.py
+++ b/kiauh/utils/nginx_utils.py
@@ -1,0 +1,71 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+"""
+Pure helpers for inspecting nginx config text. Side-effect free (no file or
+process access) so they can be shared between the webui_client component and
+the https extension and unit-tested without a running nginx.
+"""
+
+from __future__ import annotations
+
+import re
+
+# matches an active TLS listen on port 443 regardless of how the parameters are
+# ordered: nginx accepts "listen 443 ssl", "listen 443 http2 ssl",
+# "listen 443 default_server ssl" and "listen [::]:443 ssl". The directive is
+# bounded to a single line (comments already stripped) by excluding ';'/'#', and
+# the \b around 443 keeps "listen 8443 ssl;" from matching.
+_HTTPS_LISTEN_RE = re.compile(r"\blisten\b[^#;]*\b443\b[^#;]*\bssl\b")
+
+
+def config_enables_https(config_text: str) -> bool:
+    """
+    Return True if the config has an ACTIVE ``listen ... 443 ssl`` directive.
+
+    Comments are ignored: each line is truncated at the first ``#`` before the
+    check, so neither a full-line comment nor a trailing comment that merely
+    mentions ``listen 443 ssl`` is mistaken for an enabled TLS server block.
+
+    :param config_text: the full nginx config text
+    :return: True if an active TLS listen directive is present, else False
+    """
+    for raw_line in config_text.splitlines():
+        code = raw_line.split("#", 1)[0]
+        if _HTTPS_LISTEN_RE.search(code):
+            return True
+    return False
+
+
+def listen_ports(config_text: str) -> set[int]:
+    """
+    Return the set of ports of every ACTIVE (non-commented) ``listen``
+    directive in the config, across all server blocks.
+
+    The port is taken from the address token right after ``listen``, keeping the
+    part after the last ``:`` so ``listen 80;``, ``listen [::]:443 ssl;`` and
+    ``listen 443 ssl http2;`` all yield the numeric port. Unlike scanning only
+    the last listen per file, this sees a 443 directive that is followed by
+    another listen - and unlike the ssl-aware check it also catches a plain,
+    non-TLS ``listen 443;`` that would still collide on the socket.
+
+    :param config_text: the full nginx config text
+    :return: the set of active listen ports
+    """
+    ports: set[int] = set()
+    for raw_line in config_text.splitlines():
+        code = raw_line.split("#", 1)[0].strip()
+        if not code.startswith("listen"):
+            continue
+        fields = code[len("listen") :].strip().rstrip(";").split()
+        if not fields:
+            continue
+        token = fields[0].split(":")[-1].strip("[]")
+        if token.isdigit():
+            ports.add(int(token))
+    return ports

--- a/kiauh/utils/tests/__init__.py
+++ b/kiauh/utils/tests/__init__.py
@@ -1,0 +1,8 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #

--- a/kiauh/utils/tests/test_input_utils.py
+++ b/kiauh/utils/tests/test_input_utils.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from typing import Any, List
+from unittest.mock import patch
 
 import pytest
 from utils.input_utils import (
     format_question,
     get_confirm,
     get_number_input,
+    get_secret_input,
     get_selection_input,
     get_string_input,
     validate_number_input,
@@ -156,3 +158,26 @@ class TestValidateNumberInput:
     def test_raises(self, value: str, min_count: int, max_count: Any) -> None:
         with pytest.raises(ValueError):
             validate_number_input(value, min_count, max_count)
+
+
+class TestGetSecretInput:
+    def test_returns_value(self) -> None:
+        with patch("utils.input_utils.getpass", return_value="s3cr3t-token") as gp:
+            assert get_secret_input("Token") == "s3cr3t-token"
+        gp.assert_called_once()
+
+    def test_reprompts_on_empty(self) -> None:
+        with patch("utils.input_utils.getpass", side_effect=["", "  ", "tok"]) as gp:
+            assert get_secret_input("Token") == "tok"
+        assert gp.call_count == 3
+
+    def test_allows_empty_when_requested(self) -> None:
+        with patch("utils.input_utils.getpass", return_value="") as gp:
+            assert get_secret_input("Token", allow_empty=True) == ""
+        gp.assert_called_once()
+
+    def test_uses_getpass_not_input(self) -> None:
+        # a secret must never go through input() (which echoes to the terminal)
+        with patch("utils.input_utils.getpass", return_value="tok"):
+            with patch("builtins.input", side_effect=AssertionError("must not echo")):
+                assert get_secret_input("Token") == "tok"

--- a/kiauh/utils/tests/test_nginx_utils.py
+++ b/kiauh/utils/tests/test_nginx_utils.py
@@ -1,0 +1,82 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from utils.nginx_utils import config_enables_https, listen_ports
+
+
+def test_true_for_active_tls_listen():
+    assert config_enables_https("server {\n    listen 443 ssl http2;\n}\n") is True
+
+
+def test_true_with_only_ssl_flag():
+    assert config_enables_https("    listen 443 ssl;\n") is True
+
+
+def test_true_for_ipv6_only_tls_listen():
+    # a hand-written site whose only active TLS listen is IPv6 still counts
+    assert config_enables_https("    listen [::]:443 ssl;\n") is True
+
+
+def test_true_when_ssl_not_immediately_after_port():
+    # nginx accepts the ssl parameter in any position after the port
+    assert config_enables_https("    listen 443 http2 ssl;\n") is True
+    assert config_enables_https("    listen 443 default_server ssl;\n") is True
+
+
+def test_false_for_higher_port_ending_in_443():
+    # 8443 must not be mistaken for 443
+    assert config_enables_https("    listen 8443 ssl;\n") is False
+
+
+def test_false_for_plain_443_without_ssl():
+    # a plain HTTP server on 443 (no ssl parameter) is not HTTPS
+    assert config_enables_https("    listen 443;\n") is False
+
+
+def test_false_for_plain_http():
+    assert config_enables_https("server {\n    listen 80;\n}\n") is False
+
+
+def test_ignores_full_line_comment():
+    # a commented-out example must not be mistaken for an enabled TLS block
+    assert config_enables_https("server {\n    # listen 443 ssl;\n}\n") is False
+
+
+def test_ignores_trailing_comment():
+    # the directive only appears after a '#', so it is not active
+    assert config_enables_https("    listen 80;  # e.g. listen 443 ssl\n") is False
+
+
+def test_false_for_empty_text():
+    assert config_enables_https("") is False
+
+
+# --------------------------------------------------------------------------- #
+# listen_ports
+# --------------------------------------------------------------------------- #
+def test_listen_ports_collects_all_blocks():
+    text = "server {\n    listen 443 ssl http2;\n}\nserver {\n    listen 8080;\n}\n"
+    assert listen_ports(text) == {443, 8080}
+
+
+def test_listen_ports_sees_443_even_when_not_last():
+    # a plain 'listen 443;' followed by another listen must still be detected
+    text = "server {\n    listen 443;\n    listen 8080;\n}\n"
+    assert 443 in listen_ports(text)
+
+
+def test_listen_ports_handles_ipv6_and_address_prefix():
+    assert listen_ports("    listen [::]:443 ssl;\n") == {443}
+
+
+def test_listen_ports_ignores_commented_directives():
+    assert listen_ports("    # listen 443 ssl;\n    listen 80;\n") == {80}
+
+
+def test_listen_ports_empty_for_no_listen():
+    assert listen_ports("server {\n    server_name _;\n}\n") == set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ testpaths = [
     "kiauh/core/tests",
     "kiauh/core/settings/tests",
     "kiauh/core/simple_config_parser/tests",
+    "kiauh/extensions/https/tests",
     "kiauh/extensions/tests",
     "kiauh/tests",
     "kiauh/utils/tests",


### PR DESCRIPTION
## What

Adds an optional "Enable HTTPS" extension. It obtains a Let's Encrypt certificate via certbot's DNS-01 challenge and reconfigures the Mainsail/Fluidd nginx site into an HTTP→HTTPS redirect plus a TLS server block on port 443.

DNS-01 is used instead of HTTP-01 so it works on a printer that is only reachable on the LAN: HTTP-01 needs the CA to reach `http://<fqdn>/.well-known/...` from the public internet, which a private-IP host cannot satisfy. DNS-01 only needs an API token for a domain whose DNS is hosted by a supported provider. Supported here: Cloudflare, DigitalOcean and Linode; the provider model is a small dataclass, so adding more is a single entry.

## Why

KIAUH installs Mainsail/Fluidd behind nginx on port 80, HTTP only, with no built-in TLS option. Every LAN-only user currently hand-rolls a certbot DNS-01 issuance plus an nginx rewrite by hand. This turns it into a guided, reversible action.

## Behaviour

- Enable: gate on a Debian-based host, pick the client and DNS provider, prompt for the FQDN, email and credentials, issue the certificate, install a renewal reload hook, then apply the nginx rewrite transactionally — validate with `nginx -t` and restore the previous config if it fails, so nginx is never left unable to load.
- Disable: regenerate the original plain-HTTP site from KIAUH's own template (restoring the original listen port, read back from the live config) and reload. The certificate and credentials are kept; the manual cleanup commands are printed, not run.
- The provider token is written only to `/root/.secrets/<provider>.ini` (chmod 600 in a 700 dir), passed to the file via stdin, never as a command argument, never logged, never in KIAUH config. The prompt does not echo.

## Also included

- Fix `get_nginx_listen_port`: it took the last token of a `listen` line, so `listen 443 ssl http2;` parsed to `http2` and the port dropped to `None`. It now reads the address token after `listen`, so ssl / IPv6 / `host:port` forms resolve to the numeric port. Independent of the feature; happy to split it out.
- "Reconfigure Listen Port" now refuses to run on an HTTPS site (it would otherwise strip the TLS block and orphan the certificate).
- A no-echo secret-input helper (`get_secret_input`, via `getpass`) for credentials.

## Notes

- Maintainership: I'm happy to own this extension and act as its code owner going forward. For now `maintained_by` is set to `dw-0` by analogy with the other bundled extensions — glad to switch it to my username if you'd prefer I maintain it.
- Moonraker `cors_domains` is left unchanged: nginx is a same-origin reverse proxy, so the normal UI flow is not subject to CORS. The success dialog mentions the manual step only for the cross-origin case.
- Route53 / Google DNS are deferred — they use a different auth model (env/IAM, JSON key) rather than a single-token credentials file.

## Testing

86 new tests: pure transform with a golden snapshot, provider command/credentials assembly, secret handling, transactional apply + rollback, port round-trip, distro gate, listen-port parser edge cases, and the port-reconfigure guard. Full suite passes; ruff and mypy clean on the new modules.
