### PR TITLE
fix(webui_client): get_existing_clients always returns an empty list

### DIFF
--- a/kiauh/components/webui_client/client_utils.py
+++ b/kiauh/components/webui_client/client_utils.py
@@ -14,7 +14,7 @@ import shutil
 from json import JSONDecodeError
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, run
-from typing import List, get_args
+from typing import List
 
 from components.klipper.klipper import Klipper
 from components.webui_client import MODULE_PATH
@@ -229,13 +229,11 @@ def backup_client_config_data(client: BaseWebClient) -> None:
 
 
 def get_existing_clients() -> List[BaseWebClient]:
-    clients = list(get_args(WebClientType))
-    installed_clients: List[BaseWebClient] = []
-    for client in clients:
-        if client.client_dir.exists():
-            installed_clients.append(client)
-
-    return installed_clients
+    # WebClientType is an Enum, so typing.get_args() returns () and the old
+    # implementation always reported "no clients". Enumerate the concrete client
+    # data classes directly and keep the ones whose install dir exists.
+    clients: List[BaseWebClient] = [MainsailData(), FluiddData()]
+    return [client for client in clients if client.client_dir.exists()]
 
 
 def detect_client_cfg_conflict(curr_client: BaseWebClient) -> bool:

--- a/kiauh/components/webui_client/tests/__init__.py
+++ b/kiauh/components/webui_client/tests/__init__.py
@@ -1,0 +1,8 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #

--- a/kiauh/components/webui_client/tests/test_client_utils.py
+++ b/kiauh/components/webui_client/tests/test_client_utils.py
@@ -1,0 +1,53 @@
+# ======================================================================= #
+#  Copyright (C) 2020 - 2026 Dominik Willner <th33xitus@gmail.com>        #
+#                                                                         #
+#  This file is part of KIAUH - Klipper Installation And Update Helper    #
+#  https://github.com/dw-0/kiauh                                          #
+#                                                                         #
+#  This file may be distributed under the terms of the GNU GPLv3 license  #
+# ======================================================================= #
+from types import SimpleNamespace
+
+import components.webui_client.client_utils as cu
+from components.webui_client.client_utils import get_existing_clients
+
+
+def _client(installed: bool) -> SimpleNamespace:
+    return SimpleNamespace(client_dir=SimpleNamespace(exists=lambda: installed))
+
+
+def test_get_existing_clients_returns_only_installed(monkeypatch) -> None:
+    mainsail = _client(installed=True)
+    fluidd = _client(installed=False)
+    monkeypatch.setattr(cu, "MainsailData", lambda: mainsail)
+    monkeypatch.setattr(cu, "FluiddData", lambda: fluidd)
+
+    # the old get_args(Enum) implementation always returned [], even with a
+    # client installed; this pins the corrected behavior
+    assert get_existing_clients() == [mainsail]
+
+
+def test_get_existing_clients_returns_only_fluidd_when_only_fluidd(monkeypatch) -> None:
+    mainsail = _client(installed=False)
+    fluidd = _client(installed=True)
+    monkeypatch.setattr(cu, "MainsailData", lambda: mainsail)
+    monkeypatch.setattr(cu, "FluiddData", lambda: fluidd)
+
+    assert get_existing_clients() == [fluidd]
+
+
+def test_get_existing_clients_returns_both_in_order(monkeypatch) -> None:
+    mainsail = _client(installed=True)
+    fluidd = _client(installed=True)
+    monkeypatch.setattr(cu, "MainsailData", lambda: mainsail)
+    monkeypatch.setattr(cu, "FluiddData", lambda: fluidd)
+
+    # both installed -> both returned, Mainsail first
+    assert get_existing_clients() == [mainsail, fluidd]
+
+
+def test_get_existing_clients_empty_when_none_installed(monkeypatch) -> None:
+    monkeypatch.setattr(cu, "MainsailData", lambda: _client(installed=False))
+    monkeypatch.setattr(cu, "FluiddData", lambda: _client(installed=False))
+
+    assert get_existing_clients() == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,9 @@ warn_unreachable = true
 
 [tool.pytest.ini_options]
 minversion = "8.2.1"
-testpaths = ["kiauh/core/simple_config_parser/tests", "kiauh/utils/tests"]
+testpaths = [
+    "kiauh/components/webui_client/tests",
+    "kiauh/core/simple_config_parser/tests",
+    "kiauh/utils/tests",
+]
 pythonpath = ["kiauh"]


### PR DESCRIPTION
## What

`get_existing_clients()` always returns an empty list, so every caller behaves as if no Mainsail/Fluidd client is installed.

## Why

It enumerates clients with `typing.get_args(WebClientType)`, but `WebClientType` is an `Enum`, not a typing union — `get_args()` on an `Enum` returns `()`. The loop body never runs and the function returns `[]` unconditionally.

Impact: the example-config generation in the Klipper and Moonraker setup services calls `get_existing_clients()` to patch an installed web client into the generated config; that step is silently skipped today. Surfaced while working on the HTTPS extension (#806), which relies on this helper to find the client to configure.

## Change

Enumerate the concrete client data classes (`MainsailData`, `FluiddData`) directly and keep the ones whose install directory exists. Adds unit tests pinning the corrected behavior (Mainsail-only, Fluidd-only, both, none), plus the test scaffolding and pytest path for `components/webui_client`.

## Testing

`pytest` (909 pass), `ruff check`, `ruff format --check`, and `mypy` all pass.
