### PR TITLE
fix: catch FileNotFoundError in get_current_branch when component dir is missing

### DIFF
--- a/kiauh/utils/git_utils.py
+++ b/kiauh/utils/git_utils.py
@@ -109,7 +109,7 @@ def get_current_branch(repo: Path) -> str | None:
         )
         return result.strip() if result else None
 
-    except CalledProcessError:
+    except (CalledProcessError, FileNotFoundError):
         return None
 
 


### PR DESCRIPTION
## Problem

On the `develop` branch, KIAUH crashes on startup with a `FileNotFoundError` when a component directory (e.g. `crowsnest`) is not yet installed:

```
[ERROR] An unexpected error occured:
[Errno 2] No such file or directory: PosixPath('/home/<user>/crowsnest')
FileNotFoundError: [Errno 2] No such file or directory: PosixPath('/home/<user>/crowsnest')
```

## Root cause

`get_current_branch()` in `kiauh/utils/git_utils.py` runs `git branch --show-current` with `cwd=repo`. When `repo` does not exist, `subprocess` raises `FileNotFoundError`, but the function only caught `CalledProcessError`, so the exception propagated up through the main menu status fetch and crashed KIAUH.

## Fix

Also catch `FileNotFoundError` so the function returns `None` (its documented behavior for an indeterminable branch), letting callers fall back gracefully.

```diff
-    except CalledProcessError:
+    except (CalledProcessError, FileNotFoundError):
         return None
```

## Testing

- Reproduced the crash on a fresh `develop` checkout with no components installed.
- After the fix, KIAUH opens the main menu normally instead of crashing.