### PR TITLE
feat(moongate): offer LAN-only mode during install

### DIFF
--- a/kiauh/extensions/moongate/moongate_extension.py
+++ b/kiauh/extensions/moongate/moongate_extension.py
@@ -93,19 +93,35 @@ class MoongateExtension(BaseExtension):
         if port is None:
             return
 
+        # LAN-only mode skips the Cloudflare tunnel + auth proxy and keeps
+        # Moonraker reachable on the LAN - for users who reach their printer
+        # over their own VPN (WireGuard/Tailscale) and want no cloud at all.
+        lan_only = get_confirm(
+            "Install in LAN-only mode (no cloud tunnel, LAN/VPN access only)?",
+            default_choice=False,
+            allow_go_back=True,
+        )
+        if lan_only is None:
+            return
+
         try:
             self._clone_or_update_repo()
 
             BackupService().backup_moonraker_conf()
 
-            # Hand off to Moongate's own installer. It is idempotent,
-            # non-interactive and env-driven: it installs cloudflared, adds the
-            # two systemd services, patches moonraker.conf and restarts
-            # Moonraker + Klipper itself.
+            # Hand off to Moongate's own installer. It is idempotent and
+            # env-driven: it installs cloudflared, adds the two systemd
+            # services, patches moonraker.conf and restarts Moonraker +
+            # Klipper itself. MOONGATE_LAN_ONLY is passed either way: an
+            # explicit value also suppresses the installer's own terminal
+            # prompt, so KIAUH users only ever see KIAUH-styled questions.
             self._run_script(
                 MOONGATE_INSTALL_SCRIPT,
                 moonraker,
-                extra_env={"MOONGATE_PORT": str(port)},
+                extra_env={
+                    "MOONGATE_PORT": str(port),
+                    "MOONGATE_LAN_ONLY": "1" if lan_only else "0",
+                },
             )
         except (GitException, CalledProcessError, OSError) as e:
             Logger.print_error(f"Error during Moongate installation:\n{e}")
@@ -118,8 +134,14 @@ class MoongateExtension(BaseExtension):
                 "\n\n",
                 "Next steps:",
                 "● Install the Moongate app on your Android device.",
-                "● Run MOONGATE_PAIR in the Klipper console (or open the pair "
-                "page printed above) and scan the QR code.",
+                (
+                    "● In the app: Add printer > Direct (LAN/VPN), then run "
+                    "MOONGATE_PAIR in the Klipper console and scan the QR (or "
+                    "type the printer's address)."
+                    if lan_only
+                    else "● Run MOONGATE_PAIR in the Klipper console (or open "
+                    "the pair page printed above) and scan the QR code."
+                ),
                 "● Updates from now on: Mainsail/Fluidd > Software Updates > Moongate.",
             ],
             margin_bottom=1,
@@ -212,6 +234,11 @@ class MoongateExtension(BaseExtension):
                 "● add two systemd services: moongate-authproxy + moongate-tunnel",
                 "● bind Moonraker to 127.0.0.1 (the auth proxy fronts the tunnel)",
                 "● add a tightly-scoped Avahi sudoers entry for LAN discovery",
+                "\n\n",
+                "Prefer no cloud at all? A LAN-only option is offered after "
+                "this dialog - it skips the tunnel, the auth proxy and the "
+                "Moonraker rebind, and the printer stays reachable over your "
+                "LAN or your own VPN only.",
                 "\n\n",
                 "Remote access relies on cloud infrastructure operated by the "
                 "Moongate author. Moongate is licensed under PolyForm "


### PR DESCRIPTION
This **PR** is a small follow-up to #809 (the Moongate extension). Moongate v0.9.51 added for people who reach their printers over their own VPN (WireGuard, Tailscale) and don't want a cloud tunnel at all. The Moongate installer already supports it - this just adds one extra yes/no question to the extension's install flow and passes the answer through.

**What changed**

- One new question after the existing port prompt: *"Install in LAN-only mode (no cloud tunnel, LAN/VPN access only)?"* - defaults to **No**, so pressing Enter installs exactly as today.
- The answer is handed to Moongate's installer as `MOONGATE_LAN_ONLY=1/0`
- The pre-install warning dialog now mentions the LAN-only option

**Testing Via Kiauh**

- ruff check / ruff format / py_compile: all clean.
- Menu flow on a Raspberry Pi: tested in KIAUH's Extensions menu on MainsailOS (Python 3.9). The new question appears immediately after the port prompt, defaults to No, and pressing b exits cleanly. 
- Environment hand-off: tested on the same Pi using a stub installer that logs its environment. The extension code was unchanged; only the repo path was redirected. Selecting Yes passes MOONGATE_LAN_ONLY=1, selecting No passes MOONGATE_LAN_ONLY=0. The port and detected Moonraker paths are passed correctly, and the success dialog shows the appropriate pairing step for the selected mode.
- The installer behaviour controlled by this environment variable is implemented in Moongate v0.9.51 and was tested separately in that project.

Thanks for taking a look!

PEEKYPAUL 15/07/2026
